### PR TITLE
BufferOverflowFix: fix the buffer overflow bug

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -2941,7 +2941,7 @@ tsRenameDB (nvplist * req, nvplist * res, char *_dbmt_error)
     char *exvolpath = NULL;
     char *advanced = NULL;
     char *forcedel = NULL;
-    char task_name[10];
+    char task_name[TASKNAME_LEN];
 
     const char *argv[10];
 
@@ -3089,7 +3089,7 @@ tsRenameDB (nvplist * req, nvplist * res, char *_dbmt_error)
     argv[argc++] = newdbname;
     argv[argc++] = NULL;
 
-    strcpy(task_name, "renamedb");
+    strncpy(task_name, "renamedb", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -3954,7 +3954,7 @@ ts_checkdb (nvplist * req, nvplist * res, char *_dbmt_error)
 {
     char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
     char cmd_name[CUBRID_CMD_NAME_LEN];
-    char task_name[10];
+    char task_name[TASKNAME_LEN];
     const char *argv[7];
     T_DB_SERVICE_MODE db_mode;
 
@@ -4016,7 +4016,7 @@ ts_checkdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strcpy(task_name, "checkdb");
+    strncpy(task_name, "checkdb", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
 
     return retval;
@@ -6922,7 +6922,7 @@ ts_killtran (nvplist * req, nvplist * res, char *_dbmt_error)
     char *param = NULL;
     char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
     char cmd_name[CUBRID_CMD_NAME_LEN];
-    char task_name[10];
+    char task_name[TASKNAME_LEN];
     const char *argv[10];
     int ha_mode = 0;
     int argc = 0;
@@ -7029,7 +7029,7 @@ ts_killtran (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strcpy(task_name, "killtran");
+    strncpy(task_name, "killtran", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -7046,7 +7046,7 @@ ts_lockdb (nvplist * req, nvplist * res, char *_dbmt_error)
     char buf[1024], tmpfile[PATH_MAX], tmpfile2[PATH_MAX], s[32];
     char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
     char cmd_name[CUBRID_CMD_NAME_LEN];
-    char task_name[10];
+    char task_name[TASKNAME_LEN];
 
     const char *argv[10];
     int argc = 0;
@@ -7100,7 +7100,7 @@ ts_lockdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strcpy(task_name, "lockdb");
+    strncpy(task_name, "lockdb", TASKNAME_LEN);
 
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
@@ -9865,7 +9865,7 @@ run_csql_statement (const char *sql_stat, char *dbname, char *dbuser,
 {
     char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
     char cmd_name[CUBRID_CMD_NAME_LEN];
-    char task_name[10];
+    char task_name[TASKNAME_LEN];
     const char *argv[15];
 
     int argc = 0;
@@ -9944,7 +9944,7 @@ run_csql_statement (const char *sql_stat, char *dbname, char *dbuser,
 
     SET_TRANSACTION_NO_WAIT_MODE_ENV ();
 
-    strcpy(task_name, "csql");
+    strncpy(task_name, "csql", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, outfilepath, _dbmt_error);
 
     return retval;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3089,7 +3089,7 @@ tsRenameDB (nvplist * req, nvplist * res, char *_dbmt_error)
     argv[argc++] = newdbname;
     argv[argc++] = NULL;
 
-    strncpy(task_name, "renamedb", TASKNAME_LEN);
+    strncpy (task_name, "renamedb", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -4016,7 +4016,7 @@ ts_checkdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strncpy(task_name, "checkdb", TASKNAME_LEN);
+    strncpy (task_name, "checkdb", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
 
     return retval;
@@ -7029,7 +7029,7 @@ ts_killtran (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strncpy(task_name, "killtran", TASKNAME_LEN);
+    strncpy (task_name, "killtran", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -7100,7 +7100,7 @@ ts_lockdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    strncpy(task_name, "lockdb", TASKNAME_LEN);
+    strncpy (task_name, "lockdb", TASKNAME_LEN);
 
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
@@ -9944,7 +9944,7 @@ run_csql_statement (const char *sql_stat, char *dbname, char *dbuser,
 
     SET_TRANSACTION_NO_WAIT_MODE_ENV ();
 
-    strncpy(task_name, "csql", TASKNAME_LEN);
+    strncpy (task_name, "csql", TASKNAME_LEN);
     retval = _run_child (argv, 1, task_name, outfilepath, _dbmt_error);
 
     return retval;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3089,7 +3089,7 @@ tsRenameDB (nvplist * req, nvplist * res, char *_dbmt_error)
     argv[argc++] = newdbname;
     argv[argc++] = NULL;
 
-    snprintf (task_name, TASKNAME_LEN, "%s", "renamedb");
+    strcpy(task_name, "renamedb");
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -4016,7 +4016,7 @@ ts_checkdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    snprintf (task_name, TASKNAME_LEN, "%s", "checkdb");
+    strcpy(task_name, "checkdb");
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
 
     return retval;
@@ -7029,7 +7029,7 @@ ts_killtran (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    snprintf (task_name, TASKNAME_LEN, "%s", "killtran");
+    strcpy(task_name, "killtran");
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
     {
@@ -7100,7 +7100,7 @@ ts_lockdb (nvplist * req, nvplist * res, char *_dbmt_error)
 
     argv[argc++] = NULL;
 
-    snprintf (task_name, TASKNAME_LEN, "%s", "lockdb");
+    strcpy(task_name, "lockdb");
 
     retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
     if (retval != ERR_NO_ERROR)
@@ -9944,7 +9944,7 @@ run_csql_statement (const char *sql_stat, char *dbname, char *dbuser,
 
     SET_TRANSACTION_NO_WAIT_MODE_ENV ();
 
-    snprintf (task_name, TASKNAME_LEN, "%s", "csql");
+    strcpy(task_name, "csql");
     retval = _run_child (argv, 1, task_name, outfilepath, _dbmt_error);
 
     return retval;


### PR DESCRIPTION
The task_name variable is of size 10 and TASKNAME_LEN is defined as 50. When calling the snprintf function, a buffer overflow is generated. Some operating systems detect this kind of error and kill the process.

Call stack:
```
#0  0x00007eff481b7418 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007eff481b901a in __GI_abort () at abort.c:89
#2  0x00007eff481f972a in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0x7eff48310c7f "*** %s ***: %s terminated\n") at ../sysdeps/posix/libc_fatal.c:175
#3  0x00007eff4829a89c in __GI___fortify_fail (msg=<optimized out>, msg@entry=0x7eff48310c10 **"buffer overflow detected"**) at fortify_fail.c:37
#4  0x00007eff482988a0 in __GI___chk_fail () at chk_fail.c:28
#5  0x00007eff4829801d in ___vsnprintf_chk (s=<optimized out>, maxlen=<optimized out>, flags=<optimized out>, slen=<optimized out>, format=<optimized out>, args=args@entry=0x7eff34fe45e8) at vsnprintf_chk.c:37
#6  0x00007eff48297f38 in ___snprintf_chk (s=s@entry=0x7eff34fe4750 "", maxlen=maxlen@entry=50, flags=flags@entry=1, slen=slen@entry=10, format=format@entry=0x5d638f "%s") at snprintf_chk.c:34
#7  0x0000000000428120 in snprintf (__fmt=0x5d638f "%s", __n=50, __s=0x7eff34fe4750 "") at /usr/include/x86_64-linux-gnu/bits/stdio2.h:65
#8  ts_lockdb (req=<optimized out>, res=0x7eff1402e0b0, _dbmt_error=0x7eff34fe7ab0 "?") at ../src/cm_job_task.cpp:7103
#9  0x000000000046a8f4 in ch_process_request (req=req@entry=0x7eff140133d0, res=res@entry=0x7eff1402e0b0) at ../src/cm_server_interface.cpp:296
#10 0x000000000046b06c in cm_async_request_handler (lpArg=0x7eff3004e250) at ../src/cm_server_interface.cpp:483
#11 0x00007eff498026fa in start_thread (arg=0x7eff34fe9700) at pthread_create.c:333
#12 0x00007eff48288b5d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```