### PR TITLE
Update configure.ac to handle can not find dl library 

### DIFF
--- a/server/configure.ac
+++ b/server/configure.ac
@@ -27,7 +27,7 @@ AC_PROG_RANLIB
 AC_PROG_INSTALL
 CFLAGS="$remember_CFLAGS"
 CXXFLAGS="$remember_CXXFLAGS"
-LDFLAGS="$remember_LDFLAGS"
+LDFLAGS="$remember_LDFLAGS -ldl"
 
 # Checks bit model feature.
 AC_ARG_ENABLE([64bit],


### PR DESCRIPTION
when build  cubrid 10.1.x with cubridmanager there are some linking errors like below in RHEL7.x/CentOS7.x 
undefined reference to symbol dlclose@GLIBC_2.2.5
libdl.so.2 : error adding symbols : DSO missiong from command line

modify configure.ac  to handle this error 
