### PR TITLE
Correct 'key/value' pair for remote hostname properly betwe…

### DIFF
--- a/server/src/cm_mon_stat.cpp
+++ b/server/src/cm_mon_stat.cpp
@@ -1324,11 +1324,11 @@ void cm_mon_stat::gather_daily_dbs_mon (time_t gather_time)
       has_ha_info = true;
       if ("master" == ha_res["current_node_state"].asString())
         {
-          ha_rmt_hostname = ha_res["noteA"].asString();
+          ha_rmt_hostname = ha_res["nodeA"].asString();
         }
       else
         {
-          ha_rmt_hostname = ha_res["noteB"].asString();
+          ha_rmt_hostname = ha_res["nodeB"].asString();
         }
     }
   else if (ERR_SYSTEM_CALL != ha_res["retval"].asInt())


### PR DESCRIPTION
…en caller & callee for 'cubrid applyinfo' cmd.

#10 /[RND-325]

LOG behavior ($CUBRID/log/manager/cub_manager.err)
* Before:
   - log following messages at every minute if '**support_mon_statistic=YES**' at cm.conf

[20170328 15:25:49] [ WARN] [  1091] [gather_daily_dbs_mon:1430] Get HA apply info failed, time=[1490682349], dbname=[hdb3]
[20170328 15:25:49] [ WARN] [  1091] [gather_daily_dbs_mon:1430] Get HA apply info failed, time=[1490682349], dbname=[hdb2]
[20170328 15:25:49] [ WARN] [  1091] [gather_daily_dbs_mon:1430] Get HA apply info failed, time=[1490682349], dbname=[hdb1]

* After:
   - log above messages at every minute if '**support_mon_statistic=YES**' at cm.conf AND **'HA was broken'**