### PR TITLE
[CBRD-23093] fix memory leak of ext_ut_validate_auth ()

### DIFF
--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -2560,6 +2560,7 @@ bool ext_ut_validate_auth (Json::Value &request)
   // the user doesn't exist
   if (!matches)
     {
+      dbmt_user_free (&dbmt_user);
       return false;
     }
 
@@ -2571,6 +2572,8 @@ bool ext_ut_validate_auth (Json::Value &request)
           break;
         }
     }
+
+  dbmt_user_free (&dbmt_user);
 
   // assign default authority to old users.
   if (auth_user == 0)


### PR DESCRIPTION
* caller of dbmt_user_read () should release allocated memory in dbmt_user_read () by calling dbmt_user_free ()
* ext_ut_validate_auth () calls dbmt_user_read () but it didn't release memory allocated by dbmt_user_read (), it is a cause of memory leak.