### PR TITLE
[CBRD-23639] Provide SQL_Text as a response to tranlist

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6827,7 +6827,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   char *user = NULL;
   char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
   int ha_mode = 0;
-  char buf[1024];
+  char buf[5120];
   char tmpfile[PATH_MAX];
   char errfile[PATH_MAX];
   FILE *infile = NULL;
@@ -6838,6 +6838,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   int retval = 0;
   int tmp = 0;
   T_DB_SERVICE_MODE db_mode;
+  char *sqltext;
 
   cmd_name[0] = '\0';
   buf[0] = '\0';
@@ -6875,6 +6876,8 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   cubrid_cmd_name (cmd_name);
   argv[argc++] = cmd_name;
   argv[argc++] = UTIL_OPTION_TRANLIST;
+
+  argv[argc++] = "-f";
 
   argv[argc++] = "--" TRANLIST_USER_L;
   argv[argc++] = user;
@@ -6966,10 +6969,24 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
       if (strncmp (tok[8], "***", 3) == 0)
         {
           nv_add_nvp (res, "SQL_ID", "empty");
+	  
         }
       else
         {
           nv_add_nvp (res, "SQL_ID", tok[8]);
+          sqltext = tok[8] + strlen (tok[8]) + 1;
+          while (sqltext && *sqltext)
+            {
+              if (*sqltext == ' ')
+                {
+                  sqltext++;
+                }
+              else
+                {
+                  break;
+                }
+            }
+          nv_add_nvp (res, "SQL_Text", sqltext);
         }
       nv_add_nvp (res, "close", "transaction");
     }


### PR DESCRIPTION
* If a transaction has a SQL_ID, we put SQL_Text as well.
* Server-side CUBRID utility, transit, will be modified to provide full SQL Text.