### PR TITLE
[CBRD-23748] Changed passwd handling of tranlist and killtran

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7117,7 +7117,7 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   if (dbpasswd != NULL)
     {
       if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
-          || strcmp (type, "s") == 0 || strcmp (type, "q") == 0)
+          || strcmp (type, "s") == 0)
         {
           argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
           argv[argc++] = dbpasswd;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6868,14 +6868,6 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  if ((user = nv_get_val (req, "dbuser")) == NULL)
-    {
-      strncpy (_dbmt_error, "dbuser", DBMT_ERROR_MSG_SIZE);
-      return ERR_PARAM_MISSING;
-    }
-
-  dbpasswd = nv_get_val (req, "dbpasswd");
-
   /* get database mode. */
   db_mode = uDatabaseMode (dbname, &ha_mode);
   if (db_mode == DB_SERVICE_MODE_SA)
@@ -6894,15 +6886,6 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   argv[argc++] = UTIL_OPTION_TRANLIST;
 
   argv[argc++] = "-f";
-
-  argv[argc++] = "--" TRANLIST_USER_L;
-  argv[argc++] = user;
-
-  if (dbpasswd != NULL)
-    {
-      argv[argc++] = "--" TRANLIST_PASSWORD_L;
-      argv[argc++] = dbpasswd;
-    }
 
   if (ha_mode != 0)
     {
@@ -7133,9 +7116,14 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   argv[argc++] = UTIL_OPTION_KILLTRAN;
   if (dbpasswd != NULL)
     {
-      argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
-      argv[argc++] = dbpasswd;
+      if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
+          || strcmp (type, "s") == 0 || strcmp (type, "q") == 0)
+        {
+          argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
+          argv[argc++] = dbpasswd;
+        }
     }
+
   if (strcmp (type, "i") == 0)
     {
       /* remove (+) from formated string such as "1(+) | 1(-)" */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23748
Change the way tranlist and killtran handle password.

1. tranlist
  * Remove -u and -p options

2. killtran
  * The -p option applies only to the following cases:
    * -i: with **transaction index**
    * -u: with **user name**
    * -h: with **hostname**
    * -p: with **program name**
    * -s: with **SQL_ID**