### PR TITLE
[CBRD-23892] Keep cubrid version info into static variable

### DIFF
--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -61,9 +61,6 @@ static int read_start_server_output (char *stdout_log_file,
 
 static int _size_to_byte_by_unit (double orgin_num, char unit);
 
-static int cubrid_version_major = -1;
-static int cubrid_version_minor = -1;
-
 char *
 cubrid_cmd_name (char *buf)
 {
@@ -206,8 +203,9 @@ cmd_spacedb (const char *dbname, T_CUBRID_MODE mode)
   int argc = 0;
   cubrid_err_file[0] = '\0';
 
-  if (cubrid_version_major <= 0)
+  if (IS_INVALID_CUBRID_VERS_MAJOR (cubrid_version_major))
     {
+      LOG_ERROR ("Invalid CUBRID Engine Version: %d.%d", cubrid_version_major, cubrid_version_minor);
       find_and_parse_cub_admin_version (major_version, minor_version);
       cubrid_version_major = major_version;
       cubrid_version_minor = minor_version;

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -172,7 +172,7 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
     {
       if (!fgets (strbuf, sizeof (strbuf), infile) || ! fgets (strbuf, sizeof (strbuf), infile))
         {
-           LOG_ERROR ("Spacedb is skipped due to temporalily insufficient resources");
+           LOG_ERROR ("Spacedb is skipped due to temporarily insufficient resources");
            major_version = minor_version = -1;
            return;
         }

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -206,7 +206,7 @@ cmd_spacedb (const char *dbname, T_CUBRID_MODE mode)
   int argc = 0;
   cubrid_err_file[0] = '\0';
 
-  if (cubrid_version_minor <= 0)
+  if (cubrid_version_major <= 0)
     {
       find_and_parse_cub_admin_version (major_version, minor_version);
       cubrid_version_major = major_version;

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -61,6 +61,9 @@ static int read_start_server_output (char *stdout_log_file,
 
 static int _size_to_byte_by_unit (double orgin_num, char unit);
 
+static int cubrid_version_major = -1;
+static int cubrid_version_minor = -1;
+
 char *
 cubrid_cmd_name (char *buf)
 {
@@ -169,7 +172,7 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
     {
       if (!fgets (strbuf, sizeof (strbuf), infile) || ! fgets (strbuf, sizeof (strbuf), infile))
         {
-           LOG_ERROR ("Spacedb is skipped due to temporarily insufficient resources");
+           LOG_ERROR ("Spacedb is skipped due to temporalily insufficient resources");
            major_version = minor_version = -1;
            return;
         }
@@ -203,9 +206,14 @@ cmd_spacedb (const char *dbname, T_CUBRID_MODE mode)
   int argc = 0;
   cubrid_err_file[0] = '\0';
 
-  find_and_parse_cub_admin_version (major_version, minor_version);
+  if (cubrid_version_minor <= 0)
+    {
+      find_and_parse_cub_admin_version (major_version, minor_version);
+      cubrid_version_major = major_version;
+      cubrid_version_minor = minor_version;
+    }
 
-  if (major_version < 10 || (major_version == 10 && minor_version == 0))
+  if (cubrid_version_major < 10 || (cubrid_version_minor == 10 && cubrid_version_minor == 0))
     {
       res = new SpaceDbResultOldFormat();
     }

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -613,6 +613,11 @@ extern const char *autounicas_conf_entry[AUTOUNICAS_CONF_ENTRY_NUM];
 extern const char *autobackup_period_type[AUTOBACKUP_PERIOD_TYPE_NUM];
 extern const char *autobackup_period_week[AUTOBACKUP_PERIOD_WEEK_NUM];
 
+extern int cubrid_version_major;
+extern int cubrid_version_minor;
+void find_and_parse_cub_admin_version (int &major_version, int &minor_version);
+#define IS_INVALID_CUBRID_VERS_MAJOR(major)	(major <= 0)
+
 extern int auto_conf_delete (T_DBMT_FILE_ID fid, char *dbname);
 extern int auto_conf_rename (T_DBMT_FILE_ID fid, char *src_dbname,
                              char *dest_dbname);

--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -116,6 +116,9 @@ struct worker_context
 #endif
 };
 
+int cubrid_version_major = -1;
+int cubrid_version_minor = -1;
+
 int
 bind_socket (int port)
 {
@@ -908,6 +911,9 @@ main (int argc, char **argv)
     }
 
   start_auto_thread ();
+
+  find_and_parse_cub_admin_version (cubrid_version_major, cubrid_version_minor);
+  LOG_INFO ("started '%s' with Engine Version: %d.%d", argv[0], cubrid_version_major, cubrid_version_minor);
 
   start_service ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23892

* 1st call to spacedb,  fork and execute "cubrid --version", save version info into static variable
* 2nd+ call to spacedb, use version info in static variable