### PR TITLE
[CBRD-24112] set O_CLOEXEC flag to LISTEN socket

### DIFF
--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -127,7 +127,7 @@ bind_socket (int port)
   struct sockaddr_in addr;
   int one = 1;
   int flags = 1;
-  nfd = (int) socket (AF_INET, SOCK_STREAM, 0);
+  nfd = (int) socket (AF_INET, SOCK_STREAM|O_CLOEXEC, 0);
   if (nfd < 0)
     {
       return -1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24112

**Purpose**
Prevent cub_broker listen on port 8001/tcp when cub_manager was died.

**Implementation**

**Remarks**
* All open fds of the parent are inherited by the children during the fork/exec process.
* However, descriptors with O_CLOEXEC set are closed before the exec is executing.
* Brokers forked/execed by CMS also inherit 8001/tcp sockets, which should be removed.