### PR TITLE
[CBRD-24112] Execlude O_CLOEXEC in Windows

### DIFF
--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -127,7 +127,13 @@ bind_socket (int port)
   struct sockaddr_in addr;
   int one = 1;
   int flags = 1;
+
+#ifdef WINDOWS
+  nfd = (int) socket (AF_INET, SOCK_STREAM, 0);
+#else
   nfd = (int) socket (AF_INET, SOCK_STREAM|O_CLOEXEC, 0);
+#endif
+
   if (nfd < 0)
     {
       return -1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24112

Purpose
* Missed consideration for Windows, exclude Windows for #54 ,
  (No problem found in Windows for CBRD-24112, so just exclude for Windows using #if directive)

Implementation
N/A

Remarks
N/A