### PR TITLE
[CBRD-24154] Change the way to extract SQL at gettraninfo API

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6947,7 +6947,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((num_queries = get_sql_info (tmpfile, &query_file_size)) > 0)
     {
-      query_p = (char *) calloc (1, query_file_size); //kshan
+      query_p = (char *) calloc (1, query_file_size);
       sql_info = (TS_SQL_INFO *) calloc (num_queries, sizeof (TS_SQL_INFO));
       retval = get_sql_text (tmpfile, query_p, sql_info, query_file_size);
 

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6949,15 +6949,23 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
     {
       query_p = (char *) calloc (1, query_file_size); //kshan
       sql_info = (TS_SQL_INFO *) calloc (num_queries, sizeof (TS_SQL_INFO));
-    }
+      retval = get_sql_text (tmpfile, query_p, sql_info, query_file_size);
 
-  retval = get_sql_text (tmpfile, query_p, sql_info, query_file_size);	//kshan
+      if (retval != num_queries)
+        {
+          num_queries = 0;
+          if (query_p)
+            {
+              free (query_p);
+              query_p = NULL;
+            }
 
-  if (retval != num_queries)
-    {
-      free (query_p); query_p = NULL;
-      free (sql_info); sql_info = NULL;
-      num_queries = 0;
+          if (sql_info)
+            {
+	      free (sql_info);
+	      sql_info = NULL;
+            }
+        }
     }
 
   if ((infile = fopen (tmpfile, "rt")) == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24154

**Purpose**
Change the way to extract SQL text at _gettransactioninfo ()_ API

Implementation

1. at the receipt of '_gettransactioninfo_', it invoke external sh command '**cubrid tranlist database**'

  (at the previous version, it was '**cubrid tranlist -f database**')

2.  Parse tranlist output file for
    o get size of output file for temp memory allocation size for query buffer.
    o get number of SQL_IDs to compose SQL information including (start, offset, length) in query buffer
   o parse and copy SQL_Text with SQL_ID in tranlist output file

3. Parse summary info, 'cubrid tranlist' output, for transaction info (one line is for a transaction)
   o Find SQL_ID of summary info in TS_SQL_INFO struct, if found copy SQLText for that SQL_ID

Remarks
NA