### PR TITLE
[CBRD-24221] Display filename of failed to open

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -1324,6 +1324,7 @@ ts2_get_add_broker_info (nvplist *in, nvplist *out, char *_dbmt_error)
 
   if (access (broker_conf_path, F_OK) < 0)
     {
+      strcpy (_dbmt_error, broker_conf_path);
       return ERR_FILE_OPEN_FAIL;
     }
 
@@ -1661,6 +1662,7 @@ ts_get_all_sysparam (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (access (conf_path, F_OK) < 0)
     {
+      strcpy (_dbmt_error, conf_path);
       return ERR_FILE_OPEN_FAIL;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24221

**Purpose**
In **getallsysparam** (), **getaddbrokerinfo** () CMS api, there is no code to log the file name where the error occurred. In the following subject code snippet, we know that we have to copy **_conf_path_** when both **access** () and **fopen** () call failed. However, current code missed copying filename for **access** () system call.

```
  if (access (conf_path, F_OK) < 0)
    {
      return ERR_FILE_OPEN_FAIL;
    }

  infile = fopen (conf_path, "r");
  if (infile == NULL)
    {
      strcpy (_dbmt_error, conf_path);
      return ERR_FILE_OPEN_FAIL;
    }

```
**Implementation**
N/A

**Remarks**
N/A