### PR TITLE
[CBRD-24221] Fix typo

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -1325,7 +1325,7 @@ ts2_get_add_broker_info (nvplist *in, nvplist *out, char *_dbmt_error)
 
   if (access (broker_conf_path, F_OK) < 0)
     {
-      strcpy (_dbmt_error, conf_path);
+      strcpy (_dbmt_error, broker_conf_path);
       return ERR_FILE_OPEN_FAIL;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24221

Purpose
- Correct typing error:

  conf_path-> **broker_conf_path**

Implementation
N/A

Remarks