### PR TITLE
[CBRD-24243] Use pthread_cond_timedwait () instead pthread_cond_wait ()

### DIFF
--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -235,7 +235,7 @@ uReadSystemConfig (void)
   sco.iAllow_AdminMultiCon = DEFAULT_ALLOW_MULTI_CON;
   sco.iSupportWebManager = FALSE;
   sco.iSupportMonStat = FALSE;
-  sco.iHttpTimeout = 500;
+  sco.iHttpTimeout = 30;
   sco.iAutoJobTimeout = DEFAULT_AUTOJOB_TIMEOUT;
   sco.iMaxLogFiles = DEFAULT_LOG_FILE_COUNT;
   sco.iMaxLogFileSize = DEFAULT_LOG_FILE_SIZE;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -593,7 +593,6 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
                                   "failed to run task.");
     }
 
-  time_out = 30;
   pstmt->request = request;
   pstmt->status = 0;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24243

**Purpose**

- Adapt pthread_cond_timedwait () instead of pthread_cond_wait () in cm_execute_request_async ().
- Print Error log when timeout happened (cub_manager.err)
- Prevent cub_manager from hang

**Implementation**
N/A

**Remarks**

- Change timeout to 30 secs instead of sco.iHttpTimeout (500)
- remove push_back of timed-out request (client may request again)
- We found following error message in cub_manager.err in test build.
```
[kshan@dev2 manager]$ more cub_manager.err
[20220318 14:26:23] [ERROR] [ 46770] [cm_execute_request_async:669] cm_execute_request_async : Timeout 500 secs for running 'getbrokerstatus' task.
```