### PR TITLE
[CBRD-24911] extend unloaddb/loaddb CMS API for 11.3

### DIFF
--- a/docs/api/loaddb.md
+++ b/docs/api/loaddb.md
@@ -20,6 +20,8 @@ The loaddb interface will load database from files.
 | index | index file path |
 | errorcontrolfile | FILE to control error(s) during loading |
 | ignoreclassfile | input file of class names that skip load |
+| no-user-specified-name | Find classes, serials, and triggers by their object names without their owner names |
+| schema-file-list | name of schema-file-list, list of schema file names to be used in loaddb |
 | delete_orignal_files | delete original file after load |
 
 ## Request Sample

--- a/docs/api/unloaddb.md
+++ b/docs/api/unloaddb.md
@@ -17,6 +17,9 @@ The unloaddb interface will unload database server.
 | classname | unload class name |
 | ref | include referenced tables; |
 | classonly | include specified class only |
+| as-dba | extract the same schema file as the DBA |
+| skip-index-detail | skip index deduplicate info |
+| split-schema-files | split schema information by object |
 | delimit | use '"' where an identifier begins and ends; default: don't use |
 | estimate | estimated NUMBER of instances; default: auto computed |
 | prefix | PREFIX for output files; default: the database name |

--- a/docs/api/unloaddb.md
+++ b/docs/api/unloaddb.md
@@ -18,7 +18,7 @@ The unloaddb interface will unload database server.
 | ref | include referenced tables; |
 | classonly | include specified class only |
 | as-dba | extract the same schema file as the DBA |
-| skip-index-detail | skip index deduplicate info |
+| skip-index-detail | skip with option of indexes |
 | split-schema-files | split schema information by object |
 | delimit | use '"' where an identifier begins and ends; default: don't use |
 | estimate | estimated NUMBER of instances; default: auto computed |

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -360,6 +360,9 @@
 #define UNLOAD_USER_L                           "user"
 #define UNLOAD_PASSWORD_S                       "p"
 #define UNLOAD_PASSWORD_L                       "password"
+#define UNLOAD_AS_DBA_L                         "as-dba"
+#define UNLOAD_SPLIT_SCHEMA_L                   "split-schema-files"
+#define UNLOAD_SKIP_IDX_DETAIL_L                "skip-index-detail"
 
 /* compactdb option list */
 #define COMPACT_VERBOSE_S                       'v'

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -324,6 +324,8 @@
 #define LOAD_SA_MODE_L                          "SA-mode"
 #define LOAD_CS_MODE_S                          11815
 #define LOAD_CS_MODE_L                          "CS-hidden"
+#define LOAD_NO_USER_SPECIFIED_NAME_L           "no-user-specified-name"
+#define LOAD_SCHEMA_FILE_LIST_L                 "schema-file-list"
 
 /* unloaddb option list */
 #define UNLOAD_INPUT_CLASS_FILE_S               'i'

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5250,10 +5250,11 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   if (schema_file_list_opt_flag)
     {
       char loaddb_exe_path[PATH_MAX];
+
+#if defined (WINDOWS)
       char drive [_MAX_DRIVE];
       char dir[PATH_MAX];
 
-#if defined (WINDOWS)
       if (_splitpath_s(schema_file_list, drive, _MAX_DRIVE, dir, PATH_MAX, NULL, 0, NULL, 0) == 0)
         {
           snprintf (loaddb_exe_path, PATH_MAX, "%s%s", drive, dir);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5091,6 +5091,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   int argc = 0;
   char *no_user_specified_name = NULL;
   char *schema_file_list = NULL;
+  char schema_file_list_opt [PATH_MAX];
 
   cubrid_err_file[0] = '\0';
 
@@ -5235,8 +5236,8 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
-      argv[argc++] = "--" LOAD_SCHEMA_FILE_LIST_L;
-      argv[argc++] = schema_file_list;
+      snprintf (schema_file_list_opt, PATH_MAX, "%s%s", "--" LOAD_SCHEMA_FILE_LIST_L "=", schema_file_list);
+      argv[argc++] = schema_file_list_opt;
     }
   argv[argc++] = dbname;
   argv[argc++] = NULL;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4586,6 +4586,9 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   char dba_user[32] = "dba";
   char *dbuser = NULL;
   char *dbpasswd = NULL;
+  char *skip_index_detail = NULL;
+  char *split_schema_files = NULL;
+  char *as_dba = NULL;
 
   cubrid_err_file[0] = '\0';
 
@@ -4609,6 +4612,9 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   lofile = nv_get_val (req, "lofile");
   dbuser = nv_get_val (req, "dbuser");
   dbpasswd = nv_get_val (req, "dbpasswd");
+  skip_index_detail = nv_get_val (req, "skip-index-detail");
+  split_schema_files = nv_get_val (req, "split-schema-files");
+  as_dba = nv_get_val (req, "as-dba");
 
   if (target == NULL)
     {
@@ -4759,6 +4765,18 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     {
       argv[argc++] = "--" UNLOAD_LO_COUNT_L;
       argv[argc++] = lofile;
+    }
+  if (uStringEqual (as_dba, "yes"))
+    {
+      argv[argc++] = "--" UNLOAD_AS_DBA_L;
+    }
+  if (uStringEqual (split_schema_files, "yes"))
+    {
+      argv[argc++] = "--" UNLOAD_SPLIT_SCHEMA_L;
+    }
+  if (uStringEqual (skip_index_detail, "yes"))
+    {
+      argv[argc++] = "--" UNLOAD_SKIP_IDX_DETAIL_L;
     }
 
   if (ha_mode != 0)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5089,6 +5089,8 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   char cmd_name[CUBRID_CMD_NAME_LEN];
   const char *argv[32];
   int argc = 0;
+  char *no_user_specified_name = NULL;
+  char *schema_file_list = NULL;
 
   cubrid_err_file[0] = '\0';
 
@@ -5115,6 +5117,9 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   oiduse = nv_get_val (req, "oiduse");
   nolog = nv_get_val (req, "nolog");
   statisticsuse = nv_get_val (req, "statisticsuse");
+
+  no_user_specified_name = nv_get_val (req, "no-user-specified-name");
+  schema_file_list = nv_get_val (req, "schema-file-list");
 
   db_mode = uDatabaseMode (dbname, NULL);
   if (db_mode == DB_SERVICE_MODE_SA)
@@ -5223,6 +5228,15 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     {
       argv[argc++] = "--" LOAD_IGNORE_CLASS_L;
       argv[argc++] = ignore_class_file;
+    }
+  if (uStringEqual (no_user_specified_name, "yes"))
+    {
+      argv[argc++] = "--" LOAD_NO_USER_SPECIFIED_NAME_L;
+    }
+  if (schema_file_list != NULL && uStringEqual (schema_file_list, "none"))
+    {
+      argv[argc++] = "--" LOAD_SCHEMA_FILE_LIST_L;
+      argv[argc++] = schema_file_list;
     }
   argv[argc++] = dbname;
   argv[argc++] = NULL;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5233,7 +5233,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     {
       argv[argc++] = "--" LOAD_NO_USER_SPECIFIED_NAME_L;
     }
-  if (schema_file_list != NULL && uStringEqual (schema_file_list, "none"))
+  if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
       argv[argc++] = "--" LOAD_SCHEMA_FILE_LIST_L;
       argv[argc++] = schema_file_list;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -56,6 +56,7 @@
 #endif
 #endif
 
+
 #include "cm_log.h"
 #include "cm_stat.h"
 #include "cm_porting.h"
@@ -5085,7 +5086,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   T_DB_SERVICE_MODE db_mode;
   char *dbuser, *dbpasswd;
   char cubrid_err_file[PATH_MAX];
-  int retval;
+  int retval = -1;
   char cmd_name[CUBRID_CMD_NAME_LEN];
   const char *argv[32];
   int argc = 0;
@@ -5249,13 +5250,23 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   if (schema_file_list_opt_flag)
     {
       char loaddb_exe_path[PATH_MAX];
+      char drive [_MAX_DRIVE];
+      char dir[PATH_MAX];
 
+#if defined (WINDOWS)
+      if (_splitpath_s(schema_file_list, drive, _MAX_DRIVE, dir, PATH_MAX, NULL, 0, NULL, 0) == 0)
+        {
+          snprintf (loaddb_exe_path, PATH_MAX, "%s%s", drive, dir);
+          retval = run_child_cwd (argv, loaddb_exe_path, 1, NULL, tmpfile, cubrid_err_file, NULL);
+        }
+#else
       snprintf (loaddb_exe_path, PATH_MAX, "%s", schema_file_list);
       retval = run_child_cwd (argv, dirname(loaddb_exe_path), 1, NULL, tmpfile, cubrid_err_file, NULL);
+#endif
     }
   else
     {
-      retval = run_child (argv, 1, NULL, tmpfile, cubrid_err_file, NULL);    /* loaddb */
+      retval = run_child (argv, 1, NULL, tmpfile, cubrid_err_file, NULL);
     }
 
   if (retval < 0)

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -329,7 +329,11 @@ run_child_cwd (const char *const argv[], const char * dir, int wait_flag,
                  const char *stdin_file, char *stdout_file, char *stderr_file,
                  int *exit_status)
 {
+#if defined (WINDOWS)
+  if (_chdir (dir) < 0)
+#else
   if (chdir (dir) < 0)
+#endif
     {
       return -1;
     }

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -324,6 +324,18 @@ is_process_running (const char *process_name, unsigned int sleep_time)
   return true;
 }
 
+int
+run_child_cwd (const char *const argv[], const char * dir, int wait_flag,
+                 const char *stdin_file, char *stdout_file, char *stderr_file,
+                 int *exit_status)
+{
+  if (chdir (dir) < 0)
+    {
+      return -1;
+    }
+
+  return run_child (argv, wait_flag, stdin_file, stdout_file, stderr_file, exit_status);
+}
 #if !defined(WINDOWS)
 int
 run_child_linux (const char *pname, const char *const argv[], int wait_flag,

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -210,6 +210,9 @@ int ut_get_host_stat (T_CMS_HOST_STAT *stat, char *_dbmt_error);
 int ut_get_proc_stat (T_CMS_PROC_STAT *stat, int pid);
 int ut_record_cubrid_utility_log_stderr (const char *msg);
 int ut_record_cubrid_utility_log_stdout (const char *msg);
+int run_child_cwd (const char *const argv[], const char *dir, int wait_flag,
+                     const char *stdin_file, char *stdout_file, char *stderr_file,
+                     int *exit_status);
 int run_child_linux (const char *pname, const char *const argv[], int wait_flag,
                      const char *stdin_file, char *stdout_file, char *stderr_file,
                      int *exit_status);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24911

**Purpose**: **extends** CUBRID Manager Server API for changes 11.3 CUBRID Engine
* unloaddb
  * --as-dba
  * --skip-index-detail
  * --split-schema-files
* loaddb
  * --no-user-specified-name
  * --schema-file-list
 
**Implementation**

**Remarks**
* previous commit run loaddb cmd with invalid option
 ` cubrid loaddb --schema-file-list FILE database`
* **fixed to**
` cubrid loaddb --schema-file-list=FILE database`
* **change working directory** before invoke 'cubrid loaddb' with option **--schema-file-list=FILE**
  because FILE contains relative paths to schema files (Linux: [c2332e](https://github.com/CUBRID/cubrid-manager-server/pull/82/commits/c2332e999eafb01159a8321aef3eaf3f74266c08), Windows: [085884](https://github.com/CUBRID/cubrid-manager-server/pull/82/commits/085884b31dd42f1ff4b56bb385bc33bf3d138239))