### PR TITLE
[CBRD-25002] change unloaddb logfile path

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4834,7 +4834,7 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   unlink (tmpfile);
 
   /* makeup upload result information in unload.log file */
-  snprintf (buf, sizeof (buf) - 1, "%s_unloaddb.log", dbname);
+  snprintf (buf, sizeof (buf) - 1, "%s/%s_unloaddb.log", fullpath, dbname);
   nv_add_nvp (res, "open", "result");
   if ((infile = fopen (buf, "rt")) != NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25002

**Description**
* when a user issues a command unloaddb (ASIS)
`$ cubrid unloaddb -u dba -O PATH database`
  * database_schema, database_objects files are created in the PATH directory.
  * unload logfile, **database_unloaddb.log**, was **created in the current working directory**.

* with CBRD-24623 [(#4633)](https://github.com/CUBRID/cubrid/pull/4633), 
  * all files including unloaddb log files are created in the PATH.
  * For this reason, cubrid manager server fails to read unloadb log, which is required to make a response to the client.
* To resolve this problem, it is required either
  1. _rollback_ 'unloaddb' cubrid utility to the previous to create unloaddb log in the current working directory or
  2. _change_ unloaddb logfile path in cubrid manager server to PATH/database_unloadb.log

Implementation
* Change unloaddb log file path to PATH/database_unloadb.log, from current working directory.

Remarks
* CMS always require -O option from the client, {"targetdir", "PATH"}.
* It is either user specified path or "+D" for the default ($CUBRID/share/webmanager/files/)