### PR TITLE
[CBRD-25003] remove run_child_cwd () for ts_loaddb ()

### DIFF
--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -324,22 +324,6 @@ is_process_running (const char *process_name, unsigned int sleep_time)
   return true;
 }
 
-int
-run_child_cwd (const char *const argv[], const char * dir, int wait_flag,
-                 const char *stdin_file, char *stdout_file, char *stderr_file,
-                 int *exit_status)
-{
-#if defined (WINDOWS)
-  if (_chdir (dir) < 0)
-#else
-  if (chdir (dir) < 0)
-#endif
-    {
-      return -1;
-    }
-
-  return run_child (argv, wait_flag, stdin_file, stdout_file, stderr_file, exit_status);
-}
 #if !defined(WINDOWS)
 int
 run_child_linux (const char *pname, const char *const argv[], int wait_flag,

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -210,9 +210,6 @@ int ut_get_host_stat (T_CMS_HOST_STAT *stat, char *_dbmt_error);
 int ut_get_proc_stat (T_CMS_PROC_STAT *stat, int pid);
 int ut_record_cubrid_utility_log_stderr (const char *msg);
 int ut_record_cubrid_utility_log_stdout (const char *msg);
-int run_child_cwd (const char *const argv[], const char *dir, int wait_flag,
-                     const char *stdin_file, char *stdout_file, char *stderr_file,
-                     int *exit_status);
 int run_child_linux (const char *pname, const char *const argv[], int wait_flag,
                      const char *stdin_file, char *stdout_file, char *stderr_file,
                      int *exit_status);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25003

**Description**

* we introduced run_child_cwd () at cm_util.cpp at (#82).
* it is due to 'loaddb' cannot handle schema files listed in 'database_schema_info' file properly.
* according to CBRD-24623, ([#4648](https://github.com/CUBRID/cubrid/pull/4648)) it was fixed

* before #4648, we defined run_child_cwd () as follow:
  1. we changed working directory where schema_info files located.
  2. and then, call run_child () to executes 
      `'cubrid loaddb --schema-file-list=FILE ... database'`

* now, 
  * cubrid loaddb utility can handle '--schema-file-list=FILE' regardless of current working directory.
  * Therefor, we don't need to run_child_cwd () anymore, and change it to run_child ()
  * we want rollback
    * remove run_child_cwd () function definition
    * replace run_child_cwd () call to **run_child** () regardless the loadbdb options are.
