### PR TITLE
[CBRD-25232] change CMS SSL profile to support upto TLS_v1.2

### DIFF
--- a/server/src/cm_http_server.cpp
+++ b/server/src/cm_http_server.cpp
@@ -576,9 +576,12 @@ SSL_CTX *init_SSL (const char *certificate_chain,const char *private_key)
   SSL_CTX *ctx = NULL;
   /* init SSL libray is must. */
   SSL_library_init ();
-  /* We just use SSLv3,do not support SSLv2. */
-
-  ctx = SSL_CTX_new (TLSv1_server_method ());
+  /*
+   * We support upto TLS_v1.2,
+   * The actual protocol version used will be negotiated to the highest version
+   * mutually supported by the client and the server. 
+   */
+  ctx = SSL_CTX_new (TLS_server_method ());
   if (!ctx)
     {
       LOG_ERROR ("-- Web server: Fail to generate CTX for openSSL.");

--- a/server/src/cm_http_server.cpp
+++ b/server/src/cm_http_server.cpp
@@ -576,11 +576,7 @@ SSL_CTX *init_SSL (const char *certificate_chain,const char *private_key)
   SSL_CTX *ctx = NULL;
   /* init SSL libray is must. */
   SSL_library_init ();
-  /*
-   * We support upto TLS_v1.2,
-   * The actual protocol version used will be negotiated to the highest version
-   * mutually supported by the client and the server. 
-   */
+  /* Currently, we support upto TLS_v1.2 */
   ctx = SSL_CTX_new (TLS_server_method ());
   if (!ctx)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25232

**Description**
* change CMS SSL profile to support up to TLS_v1.2 by negotiation at the connection establishment.