### PR TITLE
[CBRD-25232] [11.2] change CMS SSL profile to support upto TLS_v1.2

### DIFF
--- a/server/src/cm_http_server.cpp
+++ b/server/src/cm_http_server.cpp
@@ -576,9 +576,9 @@ SSL_CTX *init_SSL (const char *certificate_chain,const char *private_key)
   SSL_CTX *ctx = NULL;
   /* init SSL libray is must. */
   SSL_library_init ();
-  /* We just use SSLv3,do not support SSLv2. */
 
-  ctx = SSL_CTX_new (TLSv1_server_method ());
+  /* Currently, we support upto TLS_v1.2 */
+  ctx = SSL_CTX_new (TLS_server_method ());
   if (!ctx)
     {
       LOG_ERROR ("-- Web server: Fail to generate CTX for openSSL.");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25232

**Description**
* this is backport of https://github.com/CUBRID/cubrid-manager-server/pull/85 to release/11.2

**Remarks**
* change CMS SSL profile to support up to TLS_v1.2 by negotiation at the connection establishment.