### PR TITLE
[CBRD-25232] 11.2, exclude Win for TLS_v1.2

### DIFF
--- a/server/src/cm_http_server.cpp
+++ b/server/src/cm_http_server.cpp
@@ -578,7 +578,11 @@ SSL_CTX *init_SSL (const char *certificate_chain,const char *private_key)
   SSL_library_init ();
 
   /* Currently, we support upto TLS_v1.2 */
+#if !defined (WINDOWS)
   ctx = SSL_CTX_new (TLS_server_method ());
+#else
+  ctx = SSL_CTX_new (TLSv1_server_method ());
+#endif
   if (!ctx)
     {
       LOG_ERROR ("-- Web server: Fail to generate CTX for openSSL.");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25232

**Description**
* this is backport of #90 to release/11.2
  * execlude windows from TLS_v1.2