### PR TITLE
[CBRD-25701] [CMS] change file type from sql_log to script

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -1292,7 +1292,7 @@ ts2_get_logfile_info (nvplist *in, nvplist *out, char *_dbmt_error)
 		}
 	      else if (strstr (cur_file, "log") != NULL)
 		{
-		  nv_add_nvp (out, "type", "sql_log");
+		  nv_add_nvp (out, "type", "script");
 		}
 	      snprintf (buf, sizeof (buf) - 1, "%s/%s", logdir, cur_file);
 	      nv_add_nvp (out, "path", buf);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25701

**Description**
* change file type in response, getlogfileinfo () API
  * ASIS: sql_log
  * TOBE: script

Remarks
* it is due to maintain backward compatibility with CM/CA with CMS