### PR TITLE
[CBRD-26020] fix for wait-for-lock error

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7119,7 +7119,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
 	{
 	  break;
 	}
-      if (string_tokenize (buf, tok, 9) < 0)
+      if (string_tokenize3 (buf, tok, 9) < 0)
 	{
 	  continue;
 	}

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6981,6 +6981,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   char *query_p = NULL;
   int query_file_size;
   TS_SQL_INFO *sql_info;
+  int has_comma[]={0, 0, 0, 0, 0, 0, 0, 1, 0};
 
   cmd_name[0] = '\0';
   buf[0] = '\0';
@@ -7119,7 +7120,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
 	{
 	  break;
 	}
-      if (string_tokenize3 (buf, tok, 9) < 0)
+      if (string_tokenize3 (buf, tok, 9, has_comma) < 0)
 	{
 	  continue;
 	}

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1780,9 +1780,9 @@ string_tokenize3 (char *str, char *tok[], int num_tok)
 		 ptr = ptr2;
                }
              else
-                {
-		  break;
-                }
+               {
+		 break;
+               }
 
            }
 

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1761,7 +1761,7 @@ string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
           return -1;
         }
 
-      if (has_comma[i - 1] && *(ptr - 1) == ',')
+      if (has_comma[i - 1] && (ptr != str) && *(ptr - 1) == ',')
         {
           for (;;)
            {

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1748,7 +1748,7 @@ string_tokenize2 (char *str, char *tok[], int num_tok, int c)
 }
 
 int
-string_tokenize3 (char *str, char *tok[], int num_tok)
+string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
 {
   int i, j;
   char *p;
@@ -1763,7 +1763,7 @@ string_tokenize3 (char *str, char *tok[], int num_tok)
           return -1;
         }
 
-      if (*(ptr - 1) == ',')
+      if (has_comma[i - 1 ] && *(ptr - 1) == ',')
         {
           for (j = 0; j < MAX_COMMA_OUNT; j++)
            {

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -86,8 +86,6 @@
 #define MAX_LINE ((int)(10*1024*1024))
 #define MIN_CHUNK 4096
 
-#define MAX_COMMA_OUNT 1000
-
 static T_FSERVER_TASK_INFO task_info[] =
 {
   {"startinfo", TS_STARTINFO, 0, DEF_TASK_FUNC (ts_startinfo), FSVR_SA, ALL_AUTHORITY},
@@ -1765,7 +1763,7 @@ string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
 
       if (has_comma[i - 1] && *(ptr - 1) == ',')
         {
-          for (j = 0; j < MAX_COMMA_OUNT; j++)
+          for (;;)
            {
              ptr++;
              ptr2 = strpbrk (ptr, " \t");
@@ -1783,13 +1781,7 @@ string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
                {
 		 break;
                }
-
            }
-
-          if (j == MAX_COMMA_OUNT)
-            {
-	      return -1;
-            }
 
           *ptr2 = '\0';
           tok[i] = ptr2;

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1748,7 +1748,7 @@ string_tokenize2 (char *str, char *tok[], int num_tok, int c)
 int
 string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
 {
-  int i, j;
+  int i;
   char *p;
   char *ptr, *ptr2;
 

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -86,6 +86,8 @@
 #define MAX_LINE ((int)(10*1024*1024))
 #define MIN_CHUNK 4096
 
+#define MAX_COMMA_OUNT 1000
+
 static T_FSERVER_TASK_INFO task_info[] =
 {
   {"startinfo", TS_STARTINFO, 0, DEF_TASK_FUNC (ts_startinfo), FSVR_SA, ALL_AUTHORITY},
@@ -1738,6 +1740,79 @@ string_tokenize2 (char *str, char *tok[], int num_tok, int c)
     }
   p = strchr (tok[num_tok - 1], c);
   if (p)
+    {
+      *p = '\0';
+    }
+
+  return 0;
+}
+
+int
+string_tokenize3 (char *str, char *tok[], int num_tok)
+{
+  int i, j;
+  char *p;
+  char *ptr, *ptr2;
+
+  tok[0] = str;
+  for (i = 1; i < num_tok; i++)
+    {
+      ptr = strpbrk (tok[i - 1], " \t");
+      if (ptr == NULL)
+        {
+          return -1;
+        }
+
+      if (*(ptr - 1) == ',')
+        {
+          for (j = 0; j < MAX_COMMA_OUNT; j++)
+           {
+             ptr++;
+             ptr2 = strpbrk (ptr, " \t");
+
+             if (ptr2 == NULL)
+               {
+		 return -1;
+               }
+
+             if (*(ptr2 - 1) == ',')
+               {
+		 ptr = ptr2;
+               }
+             else
+                {
+		  break;
+                }
+
+           }
+
+          if (j == MAX_COMMA_OUNT)
+            {
+	      return -1;
+            }
+
+          *ptr2 = '\0';
+          tok[i] = ptr2;
+        }
+      else
+        {
+          tok[i] = ptr;
+          *(tok[i]) = '\0';
+        }
+
+      p = (tok[i]) + 1;
+      for (; *p && (*p == ' ' || *p == '\t'); p++)
+	{
+	  ;
+	}
+      if (*p == '\0')
+	{
+	  return -1;
+	}
+      tok[i] = p;
+    }
+  p = strpbrk (tok[num_tok - 1], " \t");
+  if (p != NULL)
     {
       *p = '\0';
     }

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1763,7 +1763,7 @@ string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[])
           return -1;
         }
 
-      if (has_comma[i - 1 ] && *(ptr - 1) == ',')
+      if (has_comma[i - 1] && *(ptr - 1) == ',')
         {
           for (j = 0; j < MAX_COMMA_OUNT; j++)
            {

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -165,7 +165,7 @@ int ut_disk_free_space (char *path);
 char *ip2str (unsigned char *ip, char *ip_str);
 int string_tokenize (char *str, char *tok[], int num_tok);
 int string_tokenize2 (char *str, char *tok[], int num_tok, int c);
-int string_tokenize3 (char *str, char *tok[], int num_tok);
+int string_tokenize3 (char *str, char *tok[], int num_tok, int has_comma[]);
 int ut_get_task_info (const char *task, char *access_log_flag,
                       T_TASK_FUNC *task_func, T_USER_AUTH *auth);
 char *time_to_str (time_t t, const char *fmt, char *buf, int type);

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -165,6 +165,7 @@ int ut_disk_free_space (char *path);
 char *ip2str (unsigned char *ip, char *ip_str);
 int string_tokenize (char *str, char *tok[], int num_tok);
 int string_tokenize2 (char *str, char *tok[], int num_tok, int c);
+int string_tokenize3 (char *str, char *tok[], int num_tok);
 int ut_get_task_info (const char *task, char *access_log_flag,
                       T_TASK_FUNC *task_func, T_USER_AUTH *auth);
 char *time_to_str (time_t t, const char *fmt, char *buf, int type);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26020

**Description**
* 'cubrid tranlist demodb'의 output에서 wait for lock folder가 '-1'이 아닌 '3, 2, 1' 형태일때 CMS에서는 '3,'만 보여주는 오류 입니다.
* 문제는 string_tokenize () src/cm_common/cm_utils.c #544 함수가 tokenize를 할때, seperator를 {**SPACE** | **TAB**}으로 인식하는데, wait for lock folder의 output 일부에 **SPACE** 가 포함되었다는 겁니다.
* '3,' 뒤의 SPACE를 seperator로 인식하고, wait for lock folder를 '3,', SQL_ID를 '2,' 로 인식한 것이지요.
* 고민을 좀 해봤는데, 일단 release 일정도 있고해서, 엔진의 cm_common/cm_utils.c 는 그대로 두고, 이 함수를 cubridmanager/server/src/cm_server_util.cpp에 복사해서 '**gettransactioninfo**' 전용의 string_tokenize3 () 함수로 수정했습니다.
* SEPERATOR가 발견되면, 그 이전의 문자가 ','가 아니면 token을 인식한 걸로, ',' 이면 token 인식과정을 반복하는 것으로 수정했습니다.
* 현재의 수정은 매우 단순한 형태로 만들었고 추후 재 구성해야할 필요도 있을듯 합니다. 여러 종류의 접근을 생각해봤는데, 딱히 생각나는 접근 방법이 없어 이렇게 진행한 것이고,
* 접근 방법에 대햔 아이디어/comment 주시면 반영해보도록 하겠습니다.