### PR TITLE
[CBRD-26138] fix build error at Rocky Linux

### DIFF
--- a/server/configure.ac
+++ b/server/configure.ac
@@ -50,7 +50,7 @@ MACHINE_TYPE="$host_cpu"
 export SYSTEM_TYPE MACHINE_TYPE
 
 case $SYSTEM_TYPE in
-    *linux*) SYS_DEFS="-DGCC -DLINUX -D_GNU_SOURCE -DI386"
+    *linux*) SYS_DEFS="-DGCC -DLINUX -D_GNU_SOURCE -DI386 -D_GLIBCXX_USE_CXX11_ABI=0"
          SYS_LIBS="" 
          CMSTAT_LIB=""
         if test "$bit_model" = "yes"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26138

**Description**
* fix build error of CUBRID Manager Server at Rocky Linux

**Remarks**
* Even we update jsoncpp to the latest version (libjsoncpp.so.1.9.7), the same error occurs.
* We will fix the build errors first, and consider updating the jsoncpp version later.