### PR TITLE
[CBRD-26159] reflect changes in CUBRID utility output format

### DIFF
--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -386,6 +386,9 @@
 #define PLANDUMP_DROP_S                        'd'
 #define PLANDUMP_DROP_L                        "drop"
 
+/* plandump for CM compat */
+#define PLANDUMP_FOR_CM                        "for-cm"
+
 /* lockdb option list */
 #define LOCK_OUTPUT_FILE_S                      'o'
 #define LOCK_OUTPUT_FILE_L                      "output-file"
@@ -622,6 +625,7 @@ extern int cubrid_version_major;
 extern int cubrid_version_minor;
 void find_and_parse_cub_admin_version (int &major_version, int &minor_version);
 #define IS_INVALID_CUBRID_VERS_MAJOR(major)	(major <= 0)
+#define CUBRID_VERS(major,minor)	(major*100 + minor)
 
 extern int auto_conf_delete (T_DBMT_FILE_ID fid, char *dbname);
 extern int auto_conf_rename (T_DBMT_FILE_ID fid, char *src_dbname,

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -12945,6 +12945,14 @@ _ts_lockdb_parse_us (nvplist *res, FILE *infile)
 		}
 	      else
 		{
+		  scan_matched =
+		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);
+		  if (scan_matched != 1)
+		    {
+		      return -1;
+		    }
+		  nv_add_nvp (res, "numallocated", s2);
+
 	          fgets (buf, sizeof (buf), infile);
 		  scan_matched =
 		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -102,8 +102,6 @@ using namespace std;
 
 #define QUERY_BUFFER_MAX        4096
 
-#define	MAX_NUM_OBJ_LOCKS_IN_HASH_TABLE	"10000"
-
 #if !defined(WINDOWS)
 #define STRING_APPEND(buffer_p, avail_size_holder, ...)                      \
     do {                                                                     \
@@ -12935,14 +12933,28 @@ _ts_lockdb_parse_us (nvplist *res, FILE *infile)
 	      nv_add_nvp (res, "numlocked", s1);
 
 	      fgets (buf, sizeof (buf), infile);
-	      scan_matched = CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1104) ?
-		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2) :
-		      sscanf (MAX_NUM_OBJ_LOCKS_IN_HASH_TABLE, "%255s", s2);
-	      if (scan_matched != 1)
+	      if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1104))
 		{
-		  return -1;
+		  scan_matched =
+		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);
+		  if (scan_matched != 1)
+		    {
+		      return -1;
+		    }
+		  nv_add_nvp (res, "maxnumlock", s2);
 		}
-	      nv_add_nvp (res, "maxnumlock", s2);
+	      else
+		{
+	          fgets (buf, sizeof (buf), infile);
+		  scan_matched =
+		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);
+		  if (scan_matched != 1)
+		    {
+		      return -1;
+		    }
+		  nv_add_nvp (res, "sizelock", s2);
+		  nv_add_nvp (res, "maxnumlock", "-1");
+		}
 	      flag = 2;
 	    }
 	}            /* end of if (flag == 1) */

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4006,6 +4006,11 @@ ts_paramdump (nvplist *req, nvplist *res, char *_dbmt_error)
       argv[argc++] = "--" PARAMDUMP_BOTH_L;
     }
 
+  if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor >= 1105))
+    {
+      argv[argc++] = "--" PLANDUMP_FOR_CM;
+    }
+
   if (ha_mode != 0)
     {
       append_host_to_dbname (dbname_at_hostname, dbname, sizeof (dbname_at_hostname));

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -102,6 +102,8 @@ using namespace std;
 
 #define QUERY_BUFFER_MAX        4096
 
+#define	MAX_NUM_OBJ_LOCKS_IN_HASH_TABLE	"10000"
+
 #if !defined(WINDOWS)
 #define STRING_APPEND(buffer_p, avail_size_holder, ...)                      \
     do {                                                                     \
@@ -12933,8 +12935,9 @@ _ts_lockdb_parse_us (nvplist *res, FILE *infile)
 	      nv_add_nvp (res, "numlocked", s1);
 
 	      fgets (buf, sizeof (buf), infile);
-	      scan_matched =
-		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);
+	      scan_matched = CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1104) ?
+		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2) :
+		      sscanf (MAX_NUM_OBJ_LOCKS_IN_HASH_TABLE, "%255s", s2);
 	      if (scan_matched != 1)
 		{
 		  return -1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26159

**Description**
* reflect changes in CUBRID utility output format
1. plandump (cubrid plandump --for-cm demodb)
   * changed since 11.5
   * introduce '**--for-cm**' option for CM compatibility
   * refer [CUBRID#6300](https://github.com/CUBRID/cubrid/pull/6300)
 2. lockdb (cubrid lockdb demodb)
    * changed since 11.4
    * message removed: "**Maximum number of objects which can be locked**" (use 10,000 as fixed value)
    * refer [CUBRID#4685](https://github.com/CUBRID/cubrid/pull/4865)