### PR TITLE
[CBRD-26446] change logfile selection rule for getlogfileinfo API

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -357,6 +357,8 @@ static int get_next_sqltext (FILE * qfp, char *qry_buf, int offset, int query_fi
 
 static void unlink_schema_files (const char *schema_list_file);
 
+static int is_filename_matched (const char *fname, const char *pattern);
+
 static int
 _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
 		     char *_dbmt_error)
@@ -1195,7 +1197,7 @@ ts2_get_logfile_info (nvplist *in, nvplist *out, char *_dbmt_error)
 #else
 	  cur_file = dirp->d_name;
 #endif
-	  if (strstr (cur_file, bname) != NULL)
+	  if (is_filename_matched (cur_file, bname))
 	    {
 	      nv_add_nvp (out, "open", "logfile");
 	      if (strstr (cur_file, "access") != NULL)
@@ -1237,7 +1239,7 @@ ts2_get_logfile_info (nvplist *in, nvplist *out, char *_dbmt_error)
 #else
 	  cur_file = dirp->d_name;
 #endif
-	  if (strstr (cur_file, bname) != NULL)
+	  if (is_filename_matched (cur_file, bname))
 	    {
 	      nv_add_nvp (out, "open", "logfile");
 	      if (strstr (cur_file, "access") != NULL)
@@ -1283,7 +1285,7 @@ ts2_get_logfile_info (nvplist *in, nvplist *out, char *_dbmt_error)
 #else
 	  cur_file = dirp->d_name;
 #endif
-	  if (strstr (cur_file, bname) != NULL)
+	  if (is_filename_matched (cur_file, bname))
 	    {
 	      nv_add_nvp (out, "open", "logfile");
 	      if (strstr (cur_file, "access") != NULL)
@@ -16463,4 +16465,15 @@ _is_exist_default_backup_cert (char *_dbmt_error)
 	    "(%s) is not default backup SSL certification file.",
 	    default_backup_cert_path);
   return 0;
+}
+
+static int
+is_filename_matched (const char *fname, const char *pattern)
+{
+  if (fname == NULL || pattern == NULL || memcmp (fname, pattern, strlen (pattern)) || isalnum (fname[strlen (pattern)]))
+    {
+      return 0;
+    }
+
+    return 1;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26446

**Description**

* getloginfo와 getlogfileinfo에서 현재 logfile이 전송 대상인가를 결정하는 logic이 좀 다릅니다.
* getloginfo에서는 정확히 match되는 pattern을 찾는 반면,
* getlogfileinfo에서는 strstr (taget, pattern) 형식을 사용하여 'broker1'을 대상으로 할때
  broker1_1.sql.log 형태는 물론 broker11_1.sql.log 형태도 포함되는 것 같습니다.
* getlogfileinfo에서 대상 file 검색 방법을 getloginfo style로 변경합니다.
* 수정은 ts_get_log_info (), cm_job_task.cpp의 #6695 ~ #6702를 참조하였고, '**broker1**', '**broker1_**'을 구분합니다.