### PR TITLE
[CBRD-26531] check exit code of loaddb for loaddb API

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5164,6 +5164,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
   char *no_user_specified_name = NULL;
   char *schema_file_list = NULL;
   char schema_file_list_opt [PATH_MAX];
+  int exit_status = 0;
 
   cubrid_err_file[0] = '\0';
 
@@ -5316,7 +5317,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   make_temp_filepath (cubrid_err_file, sco.dbmt_tmp_dir, "loaddb_err_tmp", TS_LOADDB, PATH_MAX);
 
-  retval = run_child (argv, 1, NULL, tmpfile, cubrid_err_file, NULL);    /* loaddb */
+  retval = run_child (argv, 1, NULL, tmpfile, cubrid_err_file, &exit_status);    /* loaddb */
 
   if (retval < 0)
     {
@@ -5364,6 +5365,12 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 	{
 	  unlink_schema_files (schema_file_list);
 	}
+    }
+
+  if (exit_status != 0)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "loaddb failed with exit status: %d", WEXITSTATUS (exit_status));
+      return ERR_WITH_MSG;
     }
 
   return ERR_NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26531

**Description**:
* check exit code of 'cubrid loaddb' for loaddb api response.

**Remarks**
1. **Sample message returned when the loaddb API succeeds**
```
{
   "__EXEC_TIME" : "2862 ms",
   "line" : [
      "",
      "Start schema loading.",
      "Total       38 statements executed.",
      "Schema loading from /home/cubrid/unloabdb/demodb_schema finished.",
      "Statistics for Catalog classes have been updated.",
      "",
      "",
      "Start object loading.",
      "Total 19202 object(s) inserted, 0 object(s) failed."
   ],
   "note" : "none",
   "status" : "success",
   "task" : "loaddb"
}
```
2. **Sample ERROR message returned when the loaddb API fails**
```
   "__EXEC_TIME" : "2645 ms",
   "line" : [
      "",
      "Start schema loading.",
      "In /home/cubrid/unloaddb/demodb_schema line 8,",
      "ERROR: Serial \"public.event_no\" already exist. ",
      "",
      "Error occurred during schema loading.",
      "Aborting current transaction... done.",
      "",
      "Restart loaddb with '-s /home/cubrid/unloaddb/demodb_schema:1' option"
   ],
   "note" : "loaddb failed with exit status: 3",
   "status" : "failure",
   "task" : "loaddb"
}
```
