### PR TITLE
[CBRD-26577] fix coredump due to invalid memory free in killtran API

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7026,7 +7026,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   int num_queries = 0;
   char *query_p = NULL;
   int query_file_size;
-  TS_SQL_INFO *sql_info;
+  TS_SQL_INFO *sql_info = NULL;
   int has_comma[]={0, 0, 0, 0, 0, 0, 0, 1, 0};
 
   cmd_name[0] = '\0';

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7033,6 +7033,7 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   buf[0] = '\0';
   tmpfile[0] = '\0';
   errfile[0] = '\0';
+
   dbname_at_hostname[0] = '\0';
 
   if ((dbname = nv_get_val (req, "dbname")) == NULL)
@@ -7486,11 +7487,24 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   char cmd_name[CUBRID_CMD_NAME_LEN];
   char task_name[TASKNAME_LEN];
   const char *argv[10];
+  char *key, *value;
   int ha_mode = 0;
   int argc = 0;
   int is_need_param = 1;
   int retval = 0;
+  int i;
   T_DB_SERVICE_MODE db_mode;
+  bool dba_pw_not_present = true;
+
+  for (i = 0; i < req->nvplist_leng; i++)
+    {
+      nv_lookup (req, i, &key, &value);
+      if ((key != NULL) && (strcmp (key, "_DBPASSWD") == 0))
+        {
+          dba_pw_not_present = false;
+          break;
+        }
+    }
 
   task_name[0] = '\0';
   dbname_at_hostname[0] = '\0';
@@ -7510,6 +7524,11 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
+  if (dbpasswd == NULL && dba_pw_not_present == false)
+    {
+      dbpasswd = "";
+    }
+
   param = nv_get_val (req, "parameter");
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
@@ -7522,14 +7541,19 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   cubrid_cmd_name (cmd_name);
   argv[argc++] = cmd_name;
   argv[argc++] = UTIL_OPTION_KILLTRAN;
-  if (dbpasswd != NULL)
+
+  if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
+     || strcmp (type, "s") == 0)
     {
-      if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
-          || strcmp (type, "s") == 0)
-        {
-          argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
-          argv[argc++] = dbpasswd;
-        }
+      if (dba_pw_not_present)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "missing DBA password ('_DBPASSWD')");
+	  return ERR_WITH_MSG;
+	}
+
+      argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
+      argv[argc++] = dbpasswd;
+      argv[argc++] = "--" KILLTRAN_FORCE_L;
     }
 
   if (strcmp (type, "i") == 0)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7033,7 +7033,6 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   buf[0] = '\0';
   tmpfile[0] = '\0';
   errfile[0] = '\0';
-
   dbname_at_hostname[0] = '\0';
 
   if ((dbname = nv_get_val (req, "dbname")) == NULL)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7487,24 +7487,11 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   char cmd_name[CUBRID_CMD_NAME_LEN];
   char task_name[TASKNAME_LEN];
   const char *argv[10];
-  char *key, *value;
   int ha_mode = 0;
   int argc = 0;
   int is_need_param = 1;
   int retval = 0;
-  int i;
   T_DB_SERVICE_MODE db_mode;
-  bool dba_pw_not_present = true;
-
-  for (i = 0; i < req->nvplist_leng; i++)
-    {
-      nv_lookup (req, i, &key, &value);
-      if ((key != NULL) && (strcmp (key, "_DBPASSWD") == 0))
-        {
-          dba_pw_not_present = false;
-          break;
-        }
-    }
 
   task_name[0] = '\0';
   dbname_at_hostname[0] = '\0';
@@ -7524,11 +7511,6 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  if (dbpasswd == NULL && dba_pw_not_present == false)
-    {
-      dbpasswd = "";
-    }
-
   param = nv_get_val (req, "parameter");
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
@@ -7541,19 +7523,14 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
   cubrid_cmd_name (cmd_name);
   argv[argc++] = cmd_name;
   argv[argc++] = UTIL_OPTION_KILLTRAN;
-
-  if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
-     || strcmp (type, "s") == 0)
+  if (dbpasswd != NULL)
     {
-      if (dba_pw_not_present)
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "missing DBA password ('_DBPASSWD')");
-	  return ERR_WITH_MSG;
-	}
-
-      argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
-      argv[argc++] = dbpasswd;
-      argv[argc++] = "--" KILLTRAN_FORCE_L;
+      if (strcmp (type, "i") == 0 || strcmp (type, "u") == 0 || strcmp (type, "h") == 0 || strcmp (type, "p") == 0
+          || strcmp (type, "s") == 0)
+        {
+          argv[argc++] = "--" KILLTRAN_DBA_PASSWORD_L;
+          argv[argc++] = dbpasswd;
+        }
     }
 
   if (strcmp (type, "i") == 0)

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -259,7 +259,10 @@ ch_process_request (nvplist *req, nvplist *res)
           memset (dbpasswd, 0, 80);
           _ut_get_dbaccess (req, dbid, dbpasswd);
           nv_add_nvp (req, "_DBID", dbid);
-          nv_add_nvp (req, "_DBPASSWD", dbpasswd);
+	  if (task_code != TS_KILLTRAN)
+	    {
+	      nv_add_nvp (req, "_DBPASSWD", dbpasswd);
+	    }
           nv_add_nvp (req, "_DBNAME", dbname);
         }
     }

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -259,10 +259,7 @@ ch_process_request (nvplist *req, nvplist *res)
           memset (dbpasswd, 0, 80);
           _ut_get_dbaccess (req, dbid, dbpasswd);
           nv_add_nvp (req, "_DBID", dbid);
-	  if (task_code != TS_KILLTRAN)
-	    {
-	      nv_add_nvp (req, "_DBPASSWD", dbpasswd);
-	    }
+          nv_add_nvp (req, "_DBPASSWD", dbpasswd);
           nv_add_nvp (req, "_DBNAME", dbname);
         }
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26577

**Description**
* fix coredump by invalid memory free

Remarks
* CBRD-26577 에서 요청한 이슈는 _DBID, _DBNAME, _DBPASSWD 관련 이슈를 우선 처리하고 진행합니다.
* 본 PR에서는 coredump fix만을 처리합니다.