### PR TITLE
[CBRD-26542] verifying the existence of the renamedb volume files

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3208,6 +3208,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 		      snprintf (err_buf, DBMT_ERROR_MSG_SIZE, "volume files does not exist: %s", n);
 		      vol_file_does_not_exist = true;
 		    }
+		  continue;
 		}
 	      fprintf (outfile, "%d %s %s\n", line++, n, v);
 

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3155,6 +3155,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	  if (n == NULL)
 	    {
 	      fclose (outfile);
+	      unlink (tmpfile);
 	      if (v != NULL)
 		{
 		  strcpy (_dbmt_error, v);
@@ -3181,6 +3182,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	      if (v == NULL)
 		{
 		  fclose (outfile);
+		  unlink (tmpfile);
 		  strcpy (_dbmt_error, "invalid volume parameters");
 		  return ERR_WITH_MSG;
 		}
@@ -3229,6 +3231,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 
       if (vol_file_does_not_exist)
 	{
+	  unlink (tmpfile);
 	  DBMT_ERR_MSG_SET (_dbmt_error, err_buf);
 	  return ERR_WITH_MSG;
 	}
@@ -3258,6 +3261,9 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 
   strncpy (task_name, "renamedb", TASKNAME_LEN);
   retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
+
+  unlink (tmpfile);
+
   if (retval != ERR_NO_ERROR)
     {
       return retval;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3175,7 +3175,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	    {
 	      if (v == NULL)
 		{
-		  strcpy (_dbmt_error, "Lost all parameters.");
+		  strcpy (_dbmt_error, "invalid volume parameters")
 		  return ERR_WITH_MSG;
 		}
 #if defined(WINDOWS)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3084,10 +3084,13 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 
   char cmd_name[CUBRID_CMD_NAME_LEN];
   char tmpfile[PATH_MAX];
+  bool vol_file_does_not_exist = false;
+  char err_buf[DBMT_ERROR_MSG_SIZE];
 
   cmd_name[0] = '\0';
   tmpfile[0] = '\0';
   task_name[0] = '\0';
+  err_buf[0] = '\0';
 
   if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
     {
@@ -3198,11 +3201,31 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	      n = nt_style_path (n, n_buf);
 	      v = nt_style_path (v, v_buf);
 #endif
+	      if (access (n, F_OK) != 0)
+		{
+		  if (vol_file_does_not_exist)
+		    {
+		      int len = strlen (err_buf);
+		      snprintf (err_buf + len, DBMT_ERROR_MSG_SIZE - len, ", %s", n);
+		    }
+		  else
+		    {
+		      snprintf (err_buf, DBMT_ERROR_MSG_SIZE, "volume files does not exist: %s", n);
+		      vol_file_does_not_exist = true;
+		    }
+		}
 	      fprintf (outfile, "%d %s %s\n", line++, n, v);
 
 	    }            /* close "else if (flag == 1)" */
 	}            /* close "for" loop */
       fclose (outfile);
+
+      if (vol_file_does_not_exist)
+	{
+	  DBMT_ERR_MSG_SET (_dbmt_error, err_buf);
+	  return ERR_WITH_MSG;
+	}
+
       argv[argc++] = "--" RENAME_CONTROL_FILE_L;
       argv[argc++] = tmpfile;
     }                /* close "if (adv_flag != NULL)" */

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3155,8 +3155,16 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	  if (n == NULL)
 	    {
 	      fclose (outfile);
-	      strcpy (_dbmt_error, v != NULL ? v : "Lost all parameters.");
-	      return ERR_DIR_CREATE_FAIL;
+	      if (v != NULL)
+		{
+		  strcpy (_dbmt_error, v);
+		  return ERR_DIR_CREATE_FAIL;
+		}
+	      else
+		{
+		  strcpy (_dbmt_error, "Lost all parameters.");
+		  return ERR_WITH_MSG;
+		}
 	    }
 
 	  if (!strcmp (n, "open") && !strcmp (v, "volume"))

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3172,7 +3172,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	    {
 	      if (v == NULL)
 		{
-		  strcpy (_dbmt_error, "invalid volume parameters")
+		  strcpy (_dbmt_error, "invalid volume parameters");
 		  return ERR_WITH_MSG;
 		}
 #if defined(WINDOWS)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3262,7 +3262,10 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
   strncpy (task_name, "renamedb", TASKNAME_LEN);
   retval = _run_child (argv, 1, task_name, NULL, _dbmt_error);
 
-  unlink (tmpfile);
+  if (tmpfile[0] != '\0')
+    {
+      unlink (tmpfile);
+    }
 
   if (retval != ERR_NO_ERROR)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3173,6 +3173,11 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	    }
 	  else if (flag == 1)
 	    {
+	      if (v == NULL)
+		{
+		  strcpy (_dbmt_error, "Lost all parameters.");
+		  return ERR_WITH_MSG;
+		}
 #if defined(WINDOWS)
 	      replace_colon (n);
 	      replace_colon (v);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3155,11 +3155,8 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	  if (n == NULL)
 	    {
 	      fclose (outfile);
-	      if (v != NULL)
-		{
-		  strcpy (_dbmt_error, v);
-		  return ERR_DIR_CREATE_FAIL;
-		}
+	      strcpy (_dbmt_error, v != NULL ? v : "Lost all parameters.");
+	      return ERR_DIR_CREATE_FAIL;
 	    }
 
 	  if (!strcmp (n, "open") && !strcmp (v, "volume"))

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3172,6 +3172,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	    {
 	      if (v == NULL)
 		{
+		  fclose (outfile);
 		  strcpy (_dbmt_error, "invalid volume parameters");
 		  return ERR_WITH_MSG;
 		}

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3152,18 +3152,13 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
       for (i = 0; i < req->nvplist_leng; i++)
 	{
 	  nv_lookup (req, i, &n, &v);
-	  if (n == NULL || v == NULL)
+	  if (n == NULL)
 	    {
 	      fclose (outfile);
 	      if (v != NULL)
 		{
 		  strcpy (_dbmt_error, v);
 		  return ERR_DIR_CREATE_FAIL;
-		}
-	      else
-		{
-		  strcpy (_dbmt_error, "Lost all parameters.");
-		  return ERR_WITH_MSG;
 		}
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26542

**Description**
* verifying the existence of the volume files when key '**advanced = on**'
   * return failure with non-existent file names
* remove NULL key value check in renamedb API, because we may have NULL value for some keys, for example DB password
  * **ASIS**: key or value cannot be NULL
  * **TOBE**: key cannot be NULL

**Remarks**: sample response message of renamedb API with regard to this modification
1. Success
* request
```
{
  "task":"renamedb",
  "token":"cdfb4c5717170c5edfc2912f2940ab35013dd1336cf7d77e4cfaae281cffa1417926f07dd201b6aa",
  "dbname":"testdb",
  "rename":"testdb2",
  "exvolpath":"none",
  "advanced":"on",
  "volume":[{"/home/CUBRID/databases/testdb":"/home/CUBRID/databases/testdb2", "/home/CUBRID/databases/testdb_v1" : "/home/CUBRID/databases/testdb_vx1"}],
  "forcedel":"y"
}
```
* response
```
{
   "__EXEC_TIME" : "428 ms",
   "note" : "none",
   "status" : "success",
   "task" : "renamedb"
}
```
3. Failure: 2 requested volume files does not exist
* request
```
{
  "task":"renamedb",
  "token":"cdfb4c5717170c5edfc2912f2940ab35013dd1336cf7d77e4cfaae281cffa1417926f07dd201b6aa",
  "dbname":"testdb",
  "rename":"testdb2",
  "exvolpath":"none",
  "advanced":"on",
  "volume":[{"/hme/CUBRID/databases/testdb":"/home/CUBRID/databases/testdb2", "/home/UBRID/databases/testdb_v1" : "/home/CUBRID/databases/testdb_vx1"}],
  "forcedel":"y"
}
```
* response
```
{
   "__EXEC_TIME" : "19 ms",
   "note" : "volume files does not exist: /hme/CUBRID/databases/testdb, /home/UBRID/databases/testdb_v1",
   "status" : "failure",
   "task" : "renamedb"
}
```
