### PR TITLE
[CBRD-26611] 64-bits calculation of dbsize for getdbsize CMS API

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5750,8 +5750,8 @@ ts_get_dbsize (nvplist *req, nvplist *res, char *_dbmt_error)
   closedir (dirp);
 #endif
 
-  snprintf (strbuf, sizeof (strbuf) - 1, "%d",
-	    cmd_res->get_cnt_tpage() * cmd_res->get_page_size() + cmd_res->get_log_page_size());
+  snprintf (strbuf, sizeof (strbuf) - 1, "%lld",
+	    (int64_t) ((int64_t) cmd_res->get_cnt_tpage() * cmd_res->get_page_size() + cmd_res->get_log_page_size()));
   nv_add_nvp (res, "dbsize", strbuf);
 
   return ERR_NO_ERROR;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5659,7 +5659,8 @@ ts_get_dbsize (nvplist *req, nvplist *res, char *_dbmt_error)
   char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
   int ha_mode = 0;
   char strbuf[PATH_MAX], dbdir[PATH_MAX];
-  int no_tpage = 0, log_size = 0, baselen;
+  int no_tpage = 0, baselen;
+  long long log_size = 0;
   struct stat statbuf;
   GeneralSpacedbResult *cmd_res;
   T_CUBRID_MODE cubrid_mode;
@@ -5751,7 +5752,7 @@ ts_get_dbsize (nvplist *req, nvplist *res, char *_dbmt_error)
 #endif
 
   snprintf (strbuf, sizeof (strbuf) - 1, "%lld",
-	    (int64_t) ((int64_t) cmd_res->get_cnt_tpage() * cmd_res->get_page_size() + cmd_res->get_log_page_size()));
+	    (long long) cmd_res->get_cnt_tpage() * cmd_res->get_page_size() + cmd_res->get_log_page_size() + log_size);
   nv_add_nvp (res, "dbsize", strbuf);
 
   return ERR_NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26611

**Description**
* change printf format specifier for database size from %d to %lld
* cast calculation result to integer 64bits

**Remarks**
* cubrid createdb --db-volume-size=10G --log-volume-size=1G testdb en_US
* run getdbsize () CMS request and response from CMS 
  * **ASIS** 
{
   "__EXEC_TIME" : "10903 ms",
   "dbsize" : "-2147467264",
   "note" : "none",
   "status" : "success",
   "task" : "getdbsize"
}
  * **TOBE**
{
   "__EXEC_TIME" : "8671 ms",
   "dbsize" : "10737434624",
   "note" : "none",
   "status" : "success",
   "task" : "getdbsize"
}
  * **TOBE2: Result reflecting the log_size pointed out by the greptile comment**
{
   "__EXEC_TIME" : "5944 ms",
   "dbsize" : "12884918448",
   "note" : "none",
   "status" : "success",
   "task" : "getdbsize"
}