### PR TITLE
[CBRD-26598] remove 3hidden keys, _DBNAME/_DBID/_DBPASSWD

### DIFF
--- a/docs/api/getaddvolstatus.md
+++ b/docs/api/getaddvolstatus.md
@@ -8,6 +8,7 @@ Get volume status.
 | --- | --- |
 | task | task name |
 | token | token string encrypted. |
+| dbname | database name |
 
 ## Request Sample
 

--- a/docs/api/killtransaction.md
+++ b/docs/api/killtransaction.md
@@ -10,8 +10,7 @@ Delete transactions, and return the rest of the transactions information.
 | token | token string encrypted. |
 | dbname | database name |
 | dbuser | database username, must have dba Privileges |
-| dbpasswd | password for dbuser |
-| \_DBPASSWD | DBA password for dbname |
+| dbpassword | password for dbuser |
 | type | options from killtransaction command. |
 | parameter | a paramter according to the option in "type" field |
 
@@ -36,7 +35,7 @@ other letters should cause an error. 
   "token": "cdfb4c5717170c5eb159540c0384c7424ea3fcd68c6ea615f538801cd09c6f3a7926f07dd201b6aa",
   "dbname": "demodb",
   "dbuser": "dbuser1",
-  "dbpasswd": "1234",
+  "dbpassword": "1234",
   "_DBPASSWD": "abcd",
   "type": "i",
   "parameter": "2(+)"

--- a/docs/api/loaddb.md
+++ b/docs/api/loaddb.md
@@ -9,6 +9,8 @@ The loaddb interface will load a database from files.
 | task | task name |
 | token | token string encrypted. |
 | dbname | a name of the database |
+| dbuser | database username |
+| dbpasswd | password for dbuser |
 | checkoption | check syntax for data file or not |
 | period | insertion COUNT for periodic commit |
 | user | load databases user name |

--- a/docs/api/setautoaddvol.md
+++ b/docs/api/setautoaddvol.md
@@ -7,6 +7,7 @@ Set auto addvol option.
 | **Key** | **Description** |
 | --- | --- |
 | task | task name |
+| dbname | database name |
 | token | token string encrypted. |
 
 ## Request Sample

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3344,7 +3344,7 @@ tsStopDB (nvplist *req, nvplist *res, char *_dbmt_error)
 {
   char *dbname;
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6945,7 +6945,7 @@ ts_set_auto_add_vol (nvplist *req, nvplist *res, char *_dbmt_error)
   char *conf_item[AUTOADDVOL_CONF_ENTRY_NUM];
   int i;
 
-  if ((conf_item[0] = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((conf_item[0] = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -13450,7 +13450,7 @@ op_make_triggerinput_file_drop (nvplist *req, char *input_filename)
 
   trigger_name = nv_get_val (req, "triggername");
   /*            fprintf(input_file, ";autocommit off\n"); */
-  fprintf (input_file, "drop trigger\t%s\n", trigger_name);
+  fprintf (input_file, "drop trigger\t%s;\n", trigger_name);
   fprintf (input_file, "\n\n\ncommit;\n\n");
 
   fclose (input_file);
@@ -13491,7 +13491,7 @@ op_make_triggerinput_file_alter (nvplist *req, char *input_filename)
       fprintf (input_file, "priority %s\t", priority);
     }
 
-  fprintf (input_file, "\n\n\ncommit;\n\n");
+  fprintf (input_file, ";\n\n\ncommit;\n\n");
   fclose (input_file);
 
   return 1;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3508,7 +3508,7 @@ tsRunAddvoldb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   err_file[0] = '\0';
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5207,14 +5207,14 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   cubrid_err_file[0] = '\0';
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;
     }
 
-  dbuser = nv_get_val (req, "_DBID");
-  dbpasswd = nv_get_val (req, "_DBPASSWD");
+  dbuser = nv_get_val (req, "dbuser");
+  dbpasswd = nv_get_val (req, "dbpassword");
   checkoption = nv_get_val (req, "checkoption");
   period = nv_get_val (req, "period");
   user = nv_get_val (req, "user");

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3092,7 +3092,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
   task_name[0] = '\0';
   err_buf[0] = '\0';
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "%s", "dbname");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -3374,7 +3374,7 @@ tsDbspaceInfo (nvplist *req, nvplist *res, char *_dbmt_error)
   T_DB_SERVICE_MODE db_mode;
 
   /* get dbname */
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -16357,7 +16357,7 @@ ts_stop_statdump (nvplist *req, nvplist *res, char *_dbmt_error)
   char cmd [1024];
   int ret;
 
-  db_name = nv_get_val (req, "_DBNAME");
+  db_name = nv_get_val (req, "dbname");
   if (!db_name || (slot = find_statdumpd_info (db_name)) < 0)
    {
      nv_update_val (res, "note", "no statdump running");

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -819,7 +819,7 @@ ts_update_user (nvplist *req, nvplist *res, char *_dbmt_error)
 
   new_db_user_name = nv_get_val (req, "username");
   new_db_user_pass = nv_get_val (req, "userpass");
-  db_name = nv_get_val (req, "_DBNAME");
+  db_name = nv_get_val (req, "dbname");
 
   if (new_db_user_pass)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7026,7 +7026,7 @@ ts_get_addvol_status (nvplist *req, nvplist *res, char *_dbmt_error)
   char *dbname = NULL;
   char dbdir[PATH_MAX];
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -8395,9 +8395,9 @@ ts_trigger_operation (nvplist *req, nvplist *res, char *_dbmt_error)
 	}
     }
 
-  dbname = nv_get_val (req, "_DBNAME");
-  dbuser = nv_get_val (req, "_DBID");
-  dbpasswd = nv_get_val (req, "_DBPASSWD");
+  dbname = nv_get_val (req, "dbname");
+  dbuser = nv_get_val (req, "dbuser");
+  dbpasswd = nv_get_val (req, "dbpassword");
 
   cmd_name[0] = '\0';
   snprintf (cmd_name, sizeof (cmd_name) - 1, "%s/%s%s", sco.szCubrid,

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -16293,7 +16293,7 @@ ts_start_statdump (nvplist *req, nvplist *res, char *_dbmt_error)
   int argc = 0;
   char note [20];
   int slot = -1;
-  db_name = nv_get_val (req, "_DBNAME");
+  db_name = nv_get_val (req, "dbname");
   interval_str = nv_get_val (req, "interval");
   if (!interval_str || !db_name)
    {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6681,7 +6681,7 @@ ts_get_log_info (nvplist *req, nvplist *res, char *_dbmt_error)
   char find_file[PATH_MAX];
   char *fname;
 
-  dbname = nv_get_val (req, "_DBNAME");
+  dbname = nv_get_val (req, "dbname");
 
   if ((dbname == NULL)
       || (uRetrieveDBDirectory (dbname, log_dir) != ERR_NO_ERROR))

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6892,7 +6892,7 @@ ts_get_auto_add_vol (nvplist *req, nvplist *res, char *_dbmt_error)
   char *conf_item[AUTOADDVOL_CONF_ENTRY_NUM];
   int i;
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7542,7 +7542,13 @@ ts_killtran (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  dbpasswd = nv_get_val (req, "_DBPASSWD");
+  if (key_not_exist (req, "dbuser") || key_not_exist (req, "dbpassword"))
+    {
+      sprintf (_dbmt_error, "%s", "key \'dbuser\' or \'dbpassword\' does not exist");
+      return ERR_WITH_MSG;
+    }
+
+  dbpasswd = nv_get_val (req, "dbpassword");
 
   if ((type = nv_get_val (req, "type")) == NULL)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -13423,7 +13423,7 @@ op_make_triggerinput_file_add (nvplist *req, char *input_filename)
     {
       fprintf (input_file, "%s\t", actiontime);
     }
-  fprintf (input_file, "%s\n", action);
+  fprintf (input_file, "%s;\n", action);
   fprintf (input_file, "\n\ncommit;\n\n");
 
   fclose (input_file);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -2992,7 +2992,7 @@ tsDeleteDB (nvplist *req, nvplist *res, char *_dbmt_error)
 
   cubrid_err_file[0] = '\0';
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       sprintf (_dbmt_error, "%s", "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6373,7 +6373,7 @@ ts_get_backup_info (nvplist *req, nvplist *res, char *_dbmt_error)
   char *conf_item[AUTOBACKUP_CONF_ENTRY_NUM];
   int i;
 
-  if ((dbname = nv_get_val (req, "_DBNAME")) == NULL)
+  if ((dbname = nv_get_val (req, "dbname")) == NULL)
     {
       strcpy (_dbmt_error, "database name");
       return ERR_PARAM_MISSING;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -8731,8 +8731,9 @@ ts_get_autoexec_query (nvplist *req, nvplist *res, char *_dbmt_error)
     }
 
   nv_add_nvp (res, "open", "planlist");
-  dbname = nv_get_val (req, "_DBNAME");
+  dbname = nv_get_val (req, "dbname");
   dbmt_uid = nv_get_val (req, "_ID");
+
   if (dbname == NULL || dbmt_uid == NULL)
     {
       goto err_ts_get_autoexec_query;

--- a/server/src/cm_mon_stat.cpp
+++ b/server/src/cm_mon_stat.cpp
@@ -1014,7 +1014,6 @@ static bool get_volume_list (string dbname, Json::Value &vol_list)
 {
   Json::Value req, res;
   req["dbname"] = dbname;
-  req["_DBNAME"] = dbname;
   string errmsg;
   if (false == call_task (req, res, tsDbspaceInfo, errmsg))
     {

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -251,17 +251,6 @@ ch_process_request (nvplist *req, nvplist *res)
       return 0;
       }
       */
-
-      /* if database name is specified */
-      if (dbname)
-        {
-          memset (dbid, 0, 32);
-          memset (dbpasswd, 0, 80);
-          _ut_get_dbaccess (req, dbid, dbpasswd);
-          nv_add_nvp (req, "_DBID", dbid);
-          nv_add_nvp (req, "_DBPASSWD", dbpasswd);
-          nv_add_nvp (req, "_DBNAME", dbname);
-        }
     }
 
   /* set CLIENT_VERSION */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26598

**Description**
* remove force/hidden insertion of 3 keys in CMS requests

Remarks
* this is first commit to remove 3 keys
* A PR to complete this task is currently being processed simultaneously in the cubrid repo targeting **cm_common**.
* This is a draft, but comments are welcome.
* 문제는 CMS api를 사용하는 외부 툴 (모니터링 툴)의 호환성을 유지인데,
  * 외부 모니터링 툴들이 각각 사용하는 api set들이 파악되지 않은 상태이고
  * CMS docs를 기준으로 봤을 경우, dbname, dbuser, dbpassword이 새로이 추가되는 경우, 이전 버전의 docs에 기반하여 모니터링 툴들이 이 3개의 key를 사용하지 않았을 경우가 문제가 될수 있다.