### PR TITLE
[CBRD-26850] loaddb, check for input file existence

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -16683,13 +16683,20 @@ file_not_exist (char *path, char *_dbmt_error)
 	  return 1;
 	}
 
+      char *env_value = getenv (buf + 1);
+      if (env_value == NULL)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", path);
+	  return 1;
+	}
+
       if (p)
 	{
-	  snprintf (new_path, PATH_MAX, "%s/%s", getenv (buf + 1), p + 1);
+	  snprintf (new_path, PATH_MAX, "%s/%s", env_value, p + 1);
 	}
       else
 	{
-	  snprintf (new_path, PATH_MAX, "%s", getenv (buf + 1));
+	  snprintf (new_path, PATH_MAX, "%s", env_value);
 	}
 
       ret = access (new_path, F_OK) != 0 ? 1 : 0;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -358,7 +358,8 @@ static int get_next_sqltext (FILE * qfp, char *qry_buf, int offset, int query_fi
 static void unlink_schema_files (const char *schema_list_file);
 
 static int is_filename_matched (const char *fname, const char *pattern);
-static int file_not_exist (char *path, char *_dbmt_error);
+static int file_not_exist (char *path, char *skip_code, char *_dbmt_error);
+static int schema_file_not_exist (const char *schema_list_file, char *_dbmt_error);
 
 static int
 _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
@@ -5353,9 +5354,9 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
       argv[argc++] = schema_file_list_opt;
     }
 
-  if (file_not_exist (schema, _dbmt_error) || file_not_exist (object, _dbmt_error)
-     || file_not_exist (index, _dbmt_error) || file_not_exist (ignore_class_file, _dbmt_error)
-     || file_not_exist (schema_file_list, _dbmt_error))
+  if (file_not_exist (schema, "none", _dbmt_error) || file_not_exist (object, "none", _dbmt_error)
+     || file_not_exist (index, "none", _dbmt_error) || file_not_exist (ignore_class_file, "none", _dbmt_error)
+     || file_not_exist (schema_file_list, "none", _dbmt_error) || schema_file_not_exist (schema_file_list, _dbmt_error))
     {
       return ERR_WITH_MSG;
     }
@@ -16634,7 +16635,7 @@ is_filename_matched (const char *fname, const char *pattern)
 }
 
 static int
-file_not_exist (char *path, char *_dbmt_error)
+file_not_exist (char *path, char *skip_code, char *_dbmt_error)
 {
   char buf[PATH_MAX];
   char new_path[PATH_MAX];
@@ -16649,7 +16650,7 @@ file_not_exist (char *path, char *_dbmt_error)
   int not_allowed = 1;
   int i;
 
-  if (path == NULL || strcmp (path, "none") == 0)
+  if (path == NULL || (skip_code != NULL && strcmp (path, skip_code) == 0))
     {
       return 0;
     }
@@ -16708,4 +16709,70 @@ file_not_exist (char *path, char *_dbmt_error)
     }
 
   return ret;
+}
+
+static int
+schema_file_not_exist (const char *schema_list_file, char *_dbmt_error)
+{
+  FILE *fp;
+  char *p, filename[PATH_MAX] = { 0, };
+  char path_name[PATH_MAX*2];
+  char path[PATH_MAX];
+
+  if (schema_list_file == NULL || strcmp (schema_list_file, "none") == 0)
+    {
+      return 0;
+    }
+
+  if ((fp = fopen (schema_list_file, "r")) == NULL)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", schema_list_file);
+      return 1;
+    }
+
+#if defined (WINDOWS)
+  {
+    char drive[_MAX_DRIVE];
+    char dir[PATH_MAX];
+
+    if (_splitpath_s(schema_list_file, drive, _MAX_DRIVE, dir, PATH_MAX, NULL, 0, NULL, 0) == 0)
+      {
+	snprintf (path, PATH_MAX, "%s%s", drive, dir);
+      }
+    else
+      {
+	snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", schema_list_file);
+	fclose (fp);
+	return 1;
+      }
+  }
+#else
+  snprintf (path, PATH_MAX, "%s", schema_list_file);
+  if (dirname(path) == NULL)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", schema_list_file);
+      fclose (fp);
+      return 1;
+    }
+#endif
+
+  while (fgets (filename, PATH_MAX, fp))
+    {
+      p = strchr (filename, '\n');
+      if (p)
+	{
+	  *p = '\0';
+	}
+      snprintf (path_name, sizeof (path_name), "%s/%s", path, filename);
+
+      if (file_not_exist (path_name, NULL, _dbmt_error))
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", path_name);
+	  fclose (fp);
+	  return 1;
+	}
+    }
+
+  fclose (fp);
+  return 0;
 }

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5285,18 +5285,33 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((schema != NULL) && (strcmp (schema, "none") != 0))
     {
+      if (access (schema, F_OK) != 0)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema file does not exists: %s", schema);
+	  return ERR_WITH_MSG;
+	}
       argv[argc++] = "--" LOAD_SCHEMA_FILE_L;
       argv[argc++] = schema;
     }
 
   if ((object != NULL) && (strcmp (object, "none") != 0))
     {
+      if (access (object, F_OK) != 0)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "object file does not exists: %s", object);
+	  return ERR_WITH_MSG;
+	}
       argv[argc++] = "--" LOAD_DATA_FILE_L;
       argv[argc++] = object;
     }
 
   if ((index != NULL) && (strcmp (index, "none") != 0))
     {
+      if (access (index, F_OK) != 0)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "index file does not exists: %s", index);
+	  return ERR_WITH_MSG;
+	}
       argv[argc++] = "--" LOAD_INDEX_FILE_L;
       argv[argc++] = index;
     }
@@ -5339,6 +5354,11 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (ignore_class_file != NULL && !uStringEqual (ignore_class_file, "none"))
     {
+      if (access (ignore_class_file, F_OK) != 0)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "ignore_class_file file does not exists: %s", ignore_class_file);
+	  return ERR_WITH_MSG;
+	}
       argv[argc++] = "--" LOAD_IGNORE_CLASS_L;
       argv[argc++] = ignore_class_file;
     }
@@ -5348,6 +5368,11 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
+      if (access (schema_file_list, F_OK) != 0)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema_file_list file does not exists: %s", schema_file_list);
+	  return ERR_WITH_MSG;
+	}
       snprintf (schema_file_list_opt, PATH_MAX, "%s%s", "--" LOAD_SCHEMA_FILE_LIST_L "=", schema_file_list);
       argv[argc++] = schema_file_list_opt;
     }

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -358,7 +358,7 @@ static int get_next_sqltext (FILE * qfp, char *qry_buf, int offset, int query_fi
 static void unlink_schema_files (const char *schema_list_file);
 
 static int is_filename_matched (const char *fname, const char *pattern);
-static int file_not_exist (char *path);
+static int file_not_exist (char *path, char *_dbmt_error);
 
 static int
 _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
@@ -5286,33 +5286,18 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((schema != NULL) && (strcmp (schema, "none") != 0))
     {
-      if (file_not_exist (schema))
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema file does not exists: %s", schema);
-	  return ERR_WITH_MSG;
-	}
       argv[argc++] = "--" LOAD_SCHEMA_FILE_L;
       argv[argc++] = schema;
     }
 
   if ((object != NULL) && (strcmp (object, "none") != 0))
     {
-      if (file_not_exist (object))
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "object file does not exists: %s", object);
-	  return ERR_WITH_MSG;
-	}
       argv[argc++] = "--" LOAD_DATA_FILE_L;
       argv[argc++] = object;
     }
 
   if ((index != NULL) && (strcmp (index, "none") != 0))
     {
-      if (file_not_exist (index))
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "index file does not exists: %s", index);
-	  return ERR_WITH_MSG;
-	}
       argv[argc++] = "--" LOAD_INDEX_FILE_L;
       argv[argc++] = index;
     }
@@ -5355,11 +5340,6 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (ignore_class_file != NULL && !uStringEqual (ignore_class_file, "none"))
     {
-      if (file_not_exist (ignore_class_file))
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "ignore_class_file file does not exists: %s", ignore_class_file);
-	  return ERR_WITH_MSG;
-	}
       argv[argc++] = "--" LOAD_IGNORE_CLASS_L;
       argv[argc++] = ignore_class_file;
     }
@@ -5369,14 +5349,17 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
-      if (file_not_exist (schema_file_list))
-	{
-	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema_file_list file does not exists: %s", schema_file_list);
-	  return ERR_WITH_MSG;
-	}
       snprintf (schema_file_list_opt, PATH_MAX, "%s%s", "--" LOAD_SCHEMA_FILE_LIST_L "=", schema_file_list);
       argv[argc++] = schema_file_list_opt;
     }
+
+  if (file_not_exist (schema, _dbmt_error) || file_not_exist (object, _dbmt_error)
+     || file_not_exist (index, _dbmt_error) || file_not_exist (ignore_class_file, _dbmt_error)
+     || file_not_exist (schema_file_list, _dbmt_error))
+    {
+      return ERR_WITH_MSG;
+    }
+
   argv[argc++] = dbname;
   argv[argc++] = NULL;
 
@@ -16651,16 +16634,25 @@ is_filename_matched (const char *fname, const char *pattern)
 }
 
 static int
-file_not_exist (char *path)
+file_not_exist (char *path, char *_dbmt_error)
 {
   char buf[PATH_MAX];
   char new_path[PATH_MAX];
-  char *p;
+  char *p = NULL;
   int ret = 0;
+  char *allowed_env[]=
+  {
+    "$CUBRID",
+    "$CUBRID_DATABASES",
+  };
+  int allowed_env_len = sizeof (allowed_env) / sizeof (char *);
+  int not_allowed = 1;
+  int i;
+  int len;
 
-  if (path == NULL)
+  if (path == NULL || strcmp (path, "none") == 0)
     {
-      return 1;
+      return 0;
     }
 
   if (path[0] != '$')
@@ -16671,17 +16663,44 @@ file_not_exist (char *path)
     {
       snprintf (buf, PATH_MAX, "%s", path);
       p = strchr (buf, '/');
+
       if (p)
 	{
 	  *p = '\0';
+	}
+
+      len = strlen (buf);
+
+      for (i = 0; i < allowed_env_len; i++)
+	{
+	  if (strncmp (buf, allowed_env[i], len) == 0)
+	    {
+	      not_allowed = 0;
+	      break;
+	    }
+	}
+
+      if (not_allowed)
+	{
+	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "env variable not allowed: %s", buf);
+	  return 1;
+	}
+
+      if (p)
+	{
 	  snprintf (new_path, PATH_MAX, "%s/%s", getenv (buf + 1), p + 1);
 	}
       else
 	{
-	  snprintf (new_path, PATH_MAX, "%s", buf);
+	  snprintf (new_path, PATH_MAX, "%s", getenv (buf + 1));
 	}
 
       ret = access (new_path, F_OK) != 0 ? 1 : 0;
+    }
+
+  if (ret == 1)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", path);
     }
 
   return ret;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -16801,6 +16801,13 @@ expand_path (const char *src, char *dst, int dest_len)
 
   if (src[0] == '$')
     {
+      snprintf (buf, PATH_MAX, "%s", src);
+      p = strchr (buf, '/');
+      if (p)
+	{
+	  *p = '\0';
+	}
+
       for (i = 0; i < allowed_env_len; i++)
 	{
 	  if (strcmp (buf, allowed_env[i]) == 0)
@@ -16815,8 +16822,10 @@ expand_path (const char *src, char *dst, int dest_len)
 	  return 1;
 	}
 
-      snprintf (buf, PATH_MAX, "%s", src);
-      p = strchr (buf, '/');
+      if (p)
+	{
+	  *p = '/';
+	}
       if (p)
 	{
 	  snprintf (dst, dest_len, "%s/%s", env_num == 0 ? sco.szCubrid : sco.szCubrid_databases, p + 1);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -16648,7 +16648,6 @@ file_not_exist (char *path, char *_dbmt_error)
   int allowed_env_len = sizeof (allowed_env) / sizeof (char *);
   int not_allowed = 1;
   int i;
-  int len;
 
   if (path == NULL || strcmp (path, "none") == 0)
     {
@@ -16669,11 +16668,9 @@ file_not_exist (char *path, char *_dbmt_error)
 	  *p = '\0';
 	}
 
-      len = strlen (buf);
-
       for (i = 0; i < allowed_env_len; i++)
 	{
-	  if (strncmp (buf, allowed_env[i], len) == 0)
+	  if (strcmp (buf, allowed_env[i]) == 0)
 	    {
 	      not_allowed = 0;
 	      break;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -360,6 +360,20 @@ static void unlink_schema_files (const char *schema_list_file);
 static int is_filename_matched (const char *fname, const char *pattern);
 static int file_not_exist (char *path, char *skip_code, char *_dbmt_error);
 static int schema_file_not_exist (const char *schema_list_file, char *_dbmt_error);
+static int expand_path (const char *src, char *dst, int dest_len);
+
+static char *allowed_env[]=
+{
+  "$CUBRID",
+  "$CUBRID_DATABASES"
+};
+static int allowed_env_len = sizeof (allowed_env) / sizeof (char *);
+
+enum allowed_env_num
+{
+  ENV_CUBRID = 0,
+  ENV_CUBRID_DATABASES = 1
+};
 
 static int
 _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
@@ -16641,14 +16655,9 @@ file_not_exist (char *path, char *skip_code, char *_dbmt_error)
   char new_path[PATH_MAX];
   char *p = NULL;
   int ret = 0;
-  char *allowed_env[]=
-  {
-    "$CUBRID",
-    "$CUBRID_DATABASES",
-  };
-  int allowed_env_len = sizeof (allowed_env) / sizeof (char *);
   int not_allowed = 1;
   int i;
+
 
   if (path == NULL || (skip_code != NULL && strcmp (path, skip_code) == 0))
     {
@@ -16668,7 +16677,6 @@ file_not_exist (char *path, char *skip_code, char *_dbmt_error)
 	{
 	  *p = '\0';
 	}
-
       for (i = 0; i < allowed_env_len; i++)
 	{
 	  if (strcmp (buf, allowed_env[i]) == 0)
@@ -16718,13 +16726,14 @@ schema_file_not_exist (const char *schema_list_file, char *_dbmt_error)
   char *p, filename[PATH_MAX] = { 0, };
   char path_name[PATH_MAX*2];
   char path[PATH_MAX];
+  char full_filename[PATH_MAX];
 
   if (schema_list_file == NULL || strcmp (schema_list_file, "none") == 0)
     {
       return 0;
     }
 
-  if ((fp = fopen (schema_list_file, "r")) == NULL)
+  if (expand_path (schema_list_file, full_filename, PATH_MAX) || (fp = fopen (full_filename, "r")) == NULL)
     {
       snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "file does not exists: %s", schema_list_file);
       return 1;
@@ -16774,5 +16783,53 @@ schema_file_not_exist (const char *schema_list_file, char *_dbmt_error)
     }
 
   fclose (fp);
+  return 0;
+}
+
+static int
+expand_path (const char *src, char *dst, int dest_len)
+{
+  int i;
+  int env_num = -1;
+  char buf[PATH_MAX];
+  char *p;
+
+  if (src == NULL || dst == NULL || dest_len <= 0)
+    {
+      return 0;
+    }
+
+  if (src[0] == '$')
+    {
+      for (i = 0; i < allowed_env_len; i++)
+	{
+	  if (strcmp (buf, allowed_env[i]) == 0)
+	    {
+	      env_num = i;
+	      break;
+	    }
+	}
+
+      if (env_num < 0)
+	{
+	  return 1;
+	}
+
+      snprintf (buf, PATH_MAX, "%s", src);
+      p = strchr (buf, '/');
+      if (p)
+	{
+	  snprintf (dst, dest_len, "%s/%s", env_num == 0 ? sco.szCubrid : sco.szCubrid_databases, p + 1);
+	}
+      else
+	{
+	  snprintf (dst, dest_len, "%s", buf);
+	}
+    }
+  else
+    {
+      snprintf (dst, dest_len, "%s", src);
+    }
+
   return 0;
 }

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -358,6 +358,7 @@ static int get_next_sqltext (FILE * qfp, char *qry_buf, int offset, int query_fi
 static void unlink_schema_files (const char *schema_list_file);
 
 static int is_filename_matched (const char *fname, const char *pattern);
+static int file_not_exist (char *path);
 
 static int
 _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
@@ -5285,7 +5286,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((schema != NULL) && (strcmp (schema, "none") != 0))
     {
-      if (access (schema, F_OK) != 0)
+      if (file_not_exist (schema))
 	{
 	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema file does not exists: %s", schema);
 	  return ERR_WITH_MSG;
@@ -5296,7 +5297,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((object != NULL) && (strcmp (object, "none") != 0))
     {
-      if (access (object, F_OK) != 0)
+      if (file_not_exist (object))
 	{
 	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "object file does not exists: %s", object);
 	  return ERR_WITH_MSG;
@@ -5307,7 +5308,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((index != NULL) && (strcmp (index, "none") != 0))
     {
-      if (access (index, F_OK) != 0)
+      if (file_not_exist (index))
 	{
 	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "index file does not exists: %s", index);
 	  return ERR_WITH_MSG;
@@ -5354,7 +5355,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (ignore_class_file != NULL && !uStringEqual (ignore_class_file, "none"))
     {
-      if (access (ignore_class_file, F_OK) != 0)
+      if (file_not_exist (ignore_class_file))
 	{
 	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "ignore_class_file file does not exists: %s", ignore_class_file);
 	  return ERR_WITH_MSG;
@@ -5368,7 +5369,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
-      if (access (schema_file_list, F_OK) != 0)
+      if (file_not_exist (schema_file_list))
 	{
 	  snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "schema_file_list file does not exists: %s", schema_file_list);
 	  return ERR_WITH_MSG;
@@ -16647,4 +16648,41 @@ is_filename_matched (const char *fname, const char *pattern)
     }
 
     return 1;
+}
+
+static int
+file_not_exist (char *path)
+{
+  char buf[PATH_MAX];
+  char new_path[PATH_MAX];
+  char *p;
+  int ret = 0;
+
+  if (path == NULL)
+    {
+      return 1;
+    }
+
+  if (path[0] != '$')
+    {
+      ret = access (path, F_OK) != 0 ? 1 : 0;
+    }
+  else
+    {
+      snprintf (buf, PATH_MAX, "%s", path);
+      p = strchr (buf, '/');
+      if (p)
+	{
+	  *p = '\0';
+	  snprintf (new_path, PATH_MAX, "%s/%s", getenv (buf + 1), p + 1);
+	}
+      else
+	{
+	  snprintf (new_path, PATH_MAX, "%s", buf);
+	}
+
+      ret = access (new_path, F_OK) != 0 ? 1 : 0;
+    }
+
+  return ret;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26850

**Description**
* check existence of input files: schema, object, index, ignore_class_file, schema_file_list
* if the file does not exist, it returns an error along with the filename.

Remarks
* [PR#113](https://github.com/CUBRID/cubrid-manager-server/pull/113) 에서 run_child () exit code를 검사해서, 'failure'로 status를 반환하기는 하지만
* run_child ()를 수행하기 이전에 filename 검사가 의미가 있다고 판단해서 수정합니다.
* schema_file_list의 file들에 대해서 존재 여부의 검토는 추가할 예정입니다.