### PR TITLE
[CBRD-25862] reflect catalog changes to CMS query, db_user/_db_user

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -10113,7 +10113,9 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   int isdba = 0;
   char outfile[PATH_MAX];
   static int cmdid = 0;
-  const char *statement ="SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
+  const char *statement = CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ?
+	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;" :
+	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}      ) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
 
   targetid = nv_get_val (in, "targetid");
   dbname = nv_get_val (in, "dbname");

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4082,7 +4082,7 @@ ts_paramdump (nvplist *req, nvplist *res, char *_dbmt_error)
       argv[argc++] = "--" PARAMDUMP_BOTH_L;
     }
 
-  if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor) >= 1105)
+  if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor >= 1105))
     {
       argv[argc++] = "--" PLANDUMP_FOR_CM;
     }
@@ -13059,7 +13059,7 @@ _ts_lockdb_parse_us (nvplist *res, FILE *infile)
 	      nv_add_nvp (res, "numlocked", s1);
 
 	      fgets (buf, sizeof (buf), infile);
-	      if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1104)
+	      if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1104))
 		{
 		  scan_matched =
 		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -365,7 +365,10 @@ _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
 {
   int retval = ERR_NO_ERROR;
 
-  /* every user can access db_user table. */
+  /*
+   * All users of version 11.5 or higher can access the _db_user table,
+   * while versions lower than that can access the db_user table.
+   */
   const char *sql_stat = "select 1 from db_root";
 
   if (dbname == NULL)
@@ -10114,12 +10117,15 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   char outfile[PATH_MAX];
   static int cmdid = 0;
   const char *statement =
-	  "SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
+	  "SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from %s u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
+  char query[1024];
 
   targetid = nv_get_val (in, "targetid");
   dbname = nv_get_val (in, "dbname");
   dbuser = nv_get_val (in, "dbuser");
   dbpasswd = nv_get_val (in, "dbpasswd");
+
+  snprintf (query, 1024, statement, CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1105) ? "db_user" : "_db_user");
 
   if (dbname == NULL)
     {
@@ -10139,7 +10145,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   snprintf (outfile, sizeof (outfile) - 1, "%s/tmp/DBMT_user_login.%d",
 	    sco.szCubrid, cmdid++);
   errcode =
-	  run_csql_statement (statement, dbname, dbuser, dbpasswd, outfile, _dbmt_error);
+	  run_csql_statement (query, dbname, dbuser, dbpasswd, outfile, _dbmt_error);
   if (errcode != ERR_NO_ERROR)
     {
       return errcode;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -10115,7 +10115,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   static int cmdid = 0;
   const char *statement = CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ?
 	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;" :
-	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}      ) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
+	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
 
   targetid = nv_get_val (in, "targetid");
   dbname = nv_get_val (in, "dbname");

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -365,10 +365,7 @@ _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
 {
   int retval = ERR_NO_ERROR;
 
-  /*
-   * All users of version 11.5 or higher can access the _db_user table,
-   * while versions lower than that can access the db_user table.
-   */
+  /* every user can access db_user view. */
   const char *sql_stat = "select 1 from db_root";
 
   if (dbname == NULL)
@@ -10116,17 +10113,12 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   int isdba = 0;
   char outfile[PATH_MAX];
   static int cmdid = 0;
-  const char *statement =
-	  "SELECT COUNT( * ) FROM %s d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from %s u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
-  char query[1024];
-  const char *dbuser_nm = CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ? "db_user" : "_db_user";
+  const char *statement ="SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
 
   targetid = nv_get_val (in, "targetid");
   dbname = nv_get_val (in, "dbname");
   dbuser = nv_get_val (in, "dbuser");
   dbpasswd = nv_get_val (in, "dbpasswd");
-
-  snprintf (query, 1024, statement, dbuser_nm, dbuser_nm);
 
   if (dbname == NULL)
     {
@@ -10146,7 +10138,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   snprintf (outfile, sizeof (outfile) - 1, "%s/tmp/DBMT_user_login.%d",
 	    sco.szCubrid, cmdid++);
   errcode =
-	  run_csql_statement (query, dbname, dbuser, dbpasswd, outfile, _dbmt_error);
+	  run_csql_statement (statement, dbname, dbuser, dbpasswd, outfile, _dbmt_error);
   if (errcode != ERR_NO_ERROR)
     {
       return errcode;

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -10117,15 +10117,16 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   char outfile[PATH_MAX];
   static int cmdid = 0;
   const char *statement =
-	  "SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from %s u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
+	  "SELECT COUNT( * ) FROM %s d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from %s u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
   char query[1024];
+  const char *dbuser_nm = CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ? "db_user" : "_db_user";
 
   targetid = nv_get_val (in, "targetid");
   dbname = nv_get_val (in, "dbname");
   dbuser = nv_get_val (in, "dbuser");
   dbpasswd = nv_get_val (in, "dbpasswd");
 
-  snprintf (query, 1024, statement, CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ? "db_user" : "_db_user");
+  snprintf (query, 1024, statement, dbuser_nm, dbuser_nm);
 
   if (dbname == NULL)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4082,7 +4082,7 @@ ts_paramdump (nvplist *req, nvplist *res, char *_dbmt_error)
       argv[argc++] = "--" PARAMDUMP_BOTH_L;
     }
 
-  if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor >= 1105))
+  if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor) >= 1105)
     {
       argv[argc++] = "--" PLANDUMP_FOR_CM;
     }
@@ -10125,7 +10125,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   dbuser = nv_get_val (in, "dbuser");
   dbpasswd = nv_get_val (in, "dbpasswd");
 
-  snprintf (query, 1024, statement, CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1105) ? "db_user" : "_db_user");
+  snprintf (query, 1024, statement, CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ? "db_user" : "_db_user");
 
   if (dbname == NULL)
     {
@@ -13058,7 +13058,7 @@ _ts_lockdb_parse_us (nvplist *res, FILE *infile)
 	      nv_add_nvp (res, "numlocked", s1);
 
 	      fgets (buf, sizeof (buf), infile);
-	      if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor < 1104))
+	      if (CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1104)
 		{
 		  scan_matched =
 		      sscanf (buf, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %255s", s2);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25862

**Description**
* catalog 변경에 따른 CMS catalog query 수정
  * 11.4 이하: dbuser
  * 11.5 이상: _dbuser

**Remarks**
* @kangmin5505  의 요청에 따른 수정입니다.
* jira issue는 별도 생성하기 않고 강민님 issue를 참조했습니다 [([CBRD-25862])](http://jira.cubrid.org/browse/CBRD-25862)
* develop branch에는 진행중인 작업이 있어서, 일단 review후 feature/webmanager branch에 merge하고, 추후 develop branch에 merge 예정
* 이 PR의 범위는 아니지만 CUBRID_VERS () macro의 잘못 사용부분이 발견되어 fix 합니다. 결과적으로는 항상 true가 되었을듯합니다.
* macro의 잘못 사용에 관한 부분은 이 PR에서 제외하고, 별도의 PR로 fix 하겠습니다.