### PR TITLE
[CBRD-26916] fix autoexecquery API parsing error

### DIFF
--- a/docs/api/setautoexecquery.md
+++ b/docs/api/setautoexecquery.md
@@ -16,7 +16,27 @@ Set a configuration of a query automation.
 | detail | auto-query time (or interval,start with "i", the measurement is minutes) |
 | query_string | sql statement |
 
-## Request Sample
+## Description of 'period', 'detail'
+
+* **period**: the period must be one of the following values
+  * ONE: execute once at a specific date
+  * DAY: execute at a specific time every day
+  * WEEK: execute on a specific day every week
+  * MONTH: execute on specific days of each month
+
+* **detail**: specify the time to execute (**must have two fields**: date and time).
+  * if *period* is 'ONE', 'date' refers to specific date on which the task is to be executed <br>
+  (for example, 'ONE', '2026/09/12 12:30')
+  * if *period* is 'MONTH', 'date' refers to the day within the month on which the task is to be executed. <br>
+  (for example, 'MONTH', '1 12:00')
+  * if *period* is 'WEEK', 'date' is one of ('SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT') <br>
+  (for example, 'WEEK', 'MON 12:00')
+  * if *period* is 'DAY', 'date' is 'EVERYDAY' <br>
+  (for example 'DAY', 'EVERYDAY 12:30')
+
+  * for repeated execution, specify the time duration in seconds, starting with 'i'.
+  (for example if a query should be executed at every 60 seconds, 'DAY', 'EVERYDAY i60')
+## Request Sample: ONCE
 
 ```
 {
@@ -31,7 +51,7 @@ Set a configuration of a query automation.
           "username": "dba",
           "userpass": "none",
           "period": "ONE",
-          "detail": "$AUTO_QUERY_TIME",
+          "detail": "2026/09/12 12:30",
           "query_string": "select * from db_class;"
         }
       ]
@@ -39,6 +59,53 @@ Set a configuration of a query automation.
   ]
 }
 ```
+## Request Sample: execute once a Month
+```
+{
+  "task": "setautoexecquery",
+  "token": "cdfb4c5717170c5e99586a2763e2b6dce92982faacefb068d7e5a24b9c5fa0a37926f07dd201b6aa",
+  "dbname": "alatestdb",
+  "planlist": [
+    {
+      "queryplan": [
+        {
+          "query_id": "bbaa",
+          "username": "dba",
+          "userpass": "none",
+          "period": "MONTH",
+          "detail": "1 12:30",
+          "query_string": "select * from db_class;"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Request Sample: execute at every 60 seconds
+```
+{
+  "task": "setautoexecquery",
+  "token": "cdfb4c5717170c5e99586a2763e2b6dce92982faacefb068d7e5a24b9c5fa0a37926f07dd201b6aa",
+  "dbname": "alatestdb",
+  "planlist": [
+    {
+      "queryplan": [
+        {
+          "query_id": "bbaa",
+          "username": "dba",
+          "userpass": "none",
+          "period": "DAY",
+          "detail": "EVERYDAY i60",
+          "query_string": "select * from db_class;"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
 #
 ## Response JSON Syntax
 

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1193,7 +1193,7 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
 
   if ('i' == c->detail2[0])    // time interval for auto execute query
     {
-      int interval = 0;
+      int interval = is_positive_number (&c->detail2[1]);
       time_t prev_day_sec = 0;
       struct tm prev_tm, *tm_p;
 
@@ -1204,8 +1204,7 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
         }
       prev_tm = *tm_p;
 
-      ret = sscanf (c->detail2, "i%d", &interval);
-      if (ret != 1 || interval <= 0 || !is_positive_number (&c->detail2[1]))
+      if (interval == 0)
 	{
 	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1205,7 +1205,7 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
       prev_tm = *tm_p;
 
       ret = sscanf (c->detail2, "i%d", &interval);
-      if (ret != 1 || interval <= 0 || !is_positive_number (c->detail2))
+      if (ret != 1 || interval <= 0 || !is_positive_number (&c->detail2[1]))
 	{
 	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1201,7 +1201,7 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
       prev_tm = *tm_p;
 
       ret = sscanf (c->detail2, "i%d", &interval);
-      if (ret <= 0)
+      if (ret != 1 || interval <= 0)
 	{
 	  if (log_cnt++ < MAX_LOG_LINE)
 	    {

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1205,12 +1205,12 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
       prev_tm = *tm_p;
 
       ret = sscanf (c->detail2, "i%d", &interval);
-      if (ret != 1 || interval <= 0)
+      if (ret != 1 || interval <= 0 || !is_positive_number (c->detail2))
 	{
 	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {
-	      LOG_ERROR ("invalid interval (aj_execquery_get_exec_time DB = %s): LINE = %d, detail2 = %s, query = %s",
-			 c->dbname, c->line_num, c->detail2, c->query_string);
+	      LOG_ERROR ("invalid interval (aj_execquery_get_exec_time DB = %s): QID (%s) #%d, detail2 = %s",
+			 c->dbname, c->query_id, c->line_num, c->detail2);
 	    }
 	  return 0;
 	}
@@ -1239,8 +1239,8 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
 	{
 	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {
-	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time DB = %s): LINE = %d, detail2 = %s, query = %s",
-			 c->dbname, c->line_num, c->detail2, c->query_string);
+	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time DB = %s): QID (%s) #%d, detail2 = %s",
+			 c->dbname, c->query_id, c->line_num, c->detail2);
 	    }
 	  return 0;
 	}

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -63,8 +63,6 @@
 /*
  * To prevent repetitive logging
  */
-static int log_cnt = 0;
-
 typedef struct backup_period_details_t
 {
   int date;
@@ -140,6 +138,8 @@ typedef struct autoexecquery_t
   char detail2[16];
   char query_string[MAX_AUTOQUERY_SCRIPT_SIZE];
   int db_mode;
+  int line_num;
+  int log_cnt;
   struct autoexecquery_t *next;
 } autoexecquery_node;
 
@@ -977,6 +977,7 @@ aj_load_execquery_conf (ajob *p_aj)
   char *conf_item[AUTOEXECQUERY_CONF_ENTRY_NUM];
   char buf[MAX_JOB_CONFIG_FILE_LINE_LENGTH];
   autoexecquery_node *c;
+  int line_num = 0;
 
   p_aj->is_on = 0;
 
@@ -1009,6 +1010,7 @@ aj_load_execquery_conf (ajob *p_aj)
 
   while (fgets (buf, sizeof (buf), infile))
     {
+      line_num++;
       ut_trim (buf);
       if (buf[0] == '#' || buf[0] == '\0')
         {
@@ -1070,6 +1072,8 @@ aj_load_execquery_conf (ajob *p_aj)
       snprintf (c->query_string, sizeof (c->query_string) - 1, "%s",
                 conf_item[8]);
       c->db_mode = 2;
+      c->line_num = line_num;
+      c->log_cnt = 0;
       c->next = NULL;
     }                /* end of while */
   fclose (infile);
@@ -1203,9 +1207,10 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
       ret = sscanf (c->detail2, "i%d", &interval);
       if (ret != 1 || interval <= 0)
 	{
-	  if (log_cnt++ < MAX_LOG_LINE)
+	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {
-	      LOG_ERROR ("invalid interval (aj_execquery_get_exec_time): %s", c->detail2);
+	      LOG_ERROR ("invalid interval (aj_execquery_get_exec_time DB = %s): LINE = %d, detail2 = %s, query = %s",
+			 c->dbname, c->line_num, c->detail2, c->query_string);
 	    }
 	  return 0;
 	}
@@ -1232,9 +1237,10 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
       if (ret != 2 || exec_tm->tm_hour < 0 || exec_tm->tm_hour > 23
 	  || exec_tm->tm_min < 0 || exec_tm->tm_min > 59)
 	{
-	  if (log_cnt++ < MAX_LOG_LINE)
+	  if (c->log_cnt++ < MAX_LOG_LINE)
 	    {
-	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time): %s", c->detail2);
+	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time DB = %s): LINE = %d, detail2 = %s, query = %s",
+			 c->dbname, c->line_num, c->detail2, c->query_string);
 	    }
 	  return 0;
 	}

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -49,6 +49,7 @@
 #include "cm_cmd_exec.h"
 #include "cm_text_encryption.h"
 #include "cm_stat.h"
+#include "cm_log.h"
 
 #ifdef _DEBUG_
 #include "deb.h"
@@ -57,7 +58,12 @@
 
 #define MIN_AUTOBACKUPDB_DELAY         600
 #define MAX_AUTOADD_FREE_SPACE_RATE    0.5
+#define MAX_LOG_LINE                   10
 
+/*
+ * To prevent repetitive logging
+ */
+static int log_cnt = 0;
 
 typedef struct backup_period_details_t
 {
@@ -164,7 +170,7 @@ typedef enum
 static void aj_load_execquery_conf (ajob *p_aj);
 static void aj_execquery_handler (void *hd, time_t prev_check_time,
                                   time_t cur_time);
-static void aj_execquery_get_exec_time (autoexecquery_node *c,
+static int aj_execquery_get_exec_time (autoexecquery_node *c,
                                         query_period_details *d,
                                         struct tm *exec_tm,
                                         time_t prev_check_time);
@@ -1094,7 +1100,11 @@ aj_execquery_handler (void *hd, time_t prev_check_time, time_t cur_time)
 
       while (detail1 != NULL)
         {
-          aj_execquery_get_exec_time (c, detail1, &exec_tm, prev_check_time);
+          if (aj_execquery_get_exec_time (c, detail1, &exec_tm, prev_check_time) == 0)
+	    {
+              detail1 = detail1->next;
+              continue;
+	    }
 
           // backup tm_wday, since mktime can change tm_wday field.
           tm_wday = exec_tm.tm_wday;
@@ -1121,11 +1131,13 @@ aj_execquery_handler (void *hd, time_t prev_check_time, time_t cur_time)
   return;
 }
 
-static void
+static int
 aj_execquery_get_exec_time (autoexecquery_node *c,
                             query_period_details *d,
                             struct tm *exec_tm, time_t prev_check_time)
 {
+  int ret = -1;
+
   switch (c->period)
     {
     case AEQT_ONE:
@@ -1177,18 +1189,26 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
 
   if ('i' == c->detail2[0])    // time interval for auto execute query
     {
-      int interval;
+      int interval = 0;
       time_t prev_day_sec = 0;
       struct tm prev_tm, *tm_p;
 
       tm_p = localtime (&prev_check_time);
       if (tm_p == NULL)
         {
-          return;
+          return 0;
         }
       prev_tm = *tm_p;
 
-      sscanf (c->detail2, "i%d", &interval);
+      ret = sscanf (c->detail2, "i%d", &interval);
+      if (ret <= 0)
+	{
+	  if (log_cnt++ < MAX_LOG_LINE)
+	    {
+	      LOG_ERROR ("invalid interval (aj_execquery_get_exec_time): %s", c->detail2);
+	    }
+	  return 0;
+	}
 
       prev_day_sec =
         prev_tm.tm_hour * 3600 + prev_tm.tm_min * 60 + prev_tm.tm_sec;
@@ -1207,9 +1227,20 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
     }
   else                // specific time for auto execute query
     {
-      sscanf (c->detail2, "%d:%d", & (exec_tm->tm_hour), & (exec_tm->tm_min));
+      exec_tm->tm_hour = exec_tm->tm_min = -1;
+      ret = sscanf (c->detail2, "%d:%d", & (exec_tm->tm_hour), & (exec_tm->tm_min));
+      if (ret == 0 || exec_tm->tm_hour < 0 || exec_tm->tm_min < 0)
+	{
+	  if (log_cnt++ < MAX_LOG_LINE)
+	    {
+	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time): %s", c->detail2);
+	    }
+	}
+      return 0;
     }
   exec_tm->tm_sec = 0;
+
+  return 1;
 }
 
 static void

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1232,9 +1232,11 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
     }
   else                // specific time for auto execute query
     {
+      int matched_len = 0;
       exec_tm->tm_hour = exec_tm->tm_min = -1;
-      ret = sscanf (c->detail2, "%d:%d", & (exec_tm->tm_hour), & (exec_tm->tm_min));
-      if (ret != 2 || exec_tm->tm_hour < 0 || exec_tm->tm_hour > 23
+      ret = sscanf (c->detail2, "%d:%d%n", & (exec_tm->tm_hour), & (exec_tm->tm_min), &matched_len);
+      if (ret != 2 || c->detail2[matched_len] != '\0'
+	  || exec_tm->tm_hour < 0 || exec_tm->tm_hour > 23
 	  || exec_tm->tm_min < 0 || exec_tm->tm_min > 59)
 	{
 	  if (c->log_cnt++ < MAX_LOG_LINE)

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -1229,14 +1229,15 @@ aj_execquery_get_exec_time (autoexecquery_node *c,
     {
       exec_tm->tm_hour = exec_tm->tm_min = -1;
       ret = sscanf (c->detail2, "%d:%d", & (exec_tm->tm_hour), & (exec_tm->tm_min));
-      if (ret == 0 || exec_tm->tm_hour < 0 || exec_tm->tm_min < 0)
+      if (ret != 2 || exec_tm->tm_hour < 0 || exec_tm->tm_hour > 23
+	  || exec_tm->tm_min < 0 || exec_tm->tm_min > 59)
 	{
 	  if (log_cnt++ < MAX_LOG_LINE)
 	    {
 	      LOG_ERROR ("invalid time spec (aj_execquery_get_exec_time): %s", c->detail2);
 	    }
+	  return 0;
 	}
-      return 0;
     }
   exec_tm->tm_sec = 0;
 

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1422,7 +1422,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
 	  string interval = conf_item[6];
 
 	  interval.erase (0, 1);
-	  if (is_positive_number (interval.c_str()))
+	  if (!is_positive_number (interval.c_str()))
 	    {
 	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", conf_item[6].c_str());
 	      tmp_file.close();
@@ -2749,7 +2749,7 @@ static int is_positive_number (const char *str)
 {
   int len, i;
 
-  if (str == NULL)
+  if (str == NULL || atoi (str) == 0)
     {
       return 0;
     }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -2732,12 +2732,21 @@ int ext_get_mon_statistic (Json::Value &request, Json::Value &response)
 static int count_and_get_last_word (string str, char *word)
 {
   stringstream ss(str);
+  string token;
   int count = 0;
 
-  while (ss >> word)
+  while (ss >> token)
     {
       count++;
     }
+
+  if (token.length () >= TOKEN_LENGTH)
+    {
+      word[0] = '\0';
+      return -1;
+    }
+
+  snprintf (word, TOKEN_LENGTH, "%s", token.c_str ());
 
   return count;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1407,7 +1407,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
-      if (num_word (conf_item[6]) < 2)
+      if (num_word (conf_item[6]) < 2 && conf_item[6].c_str()[0] != 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
           snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIMEi (at least 2 words expected): %s", conf_item[6].c_str());

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -86,7 +86,7 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
   {NULL, 0, NULL, 0}
 };
 
-static int num_word (string str);
+static int count_and_get_last_word (string str, char *word);
 
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
@@ -1269,6 +1269,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
   string conf_item[AUTOEXECQUERY_CONF_ENTRY_NUM];
   fstream conf_file;
   ofstream tmp_file;
+  char interval[TOKEN_LENGTH];
 
 
   autoexecquery_conf_file[0] = '\0';
@@ -1407,23 +1408,21 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
-      if (num_word (conf_item[6]) < 2)
+      if (count_and_get_last_word (conf_item[6], interval) != 2)
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
-          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIME (at least 2 words expected): %s", conf_item[6].c_str());
+          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail: %s", conf_item[6].c_str());
           tmp_file.close();
           return build_server_header (response, ERR_WITH_MSG, tmp);
 	}
 
-      if (conf_item[6].c_str()[0] == 'i')
+      if (interval[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
-	  string interval = conf_item[6];
 
-	  interval.erase (0, 1);
-	  if (!is_positive_number (interval.c_str()))
+	  if (!is_positive_number (&interval[1]))
 	    {
-	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", conf_item[6].c_str());
+	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", interval);
 	      tmp_file.close();
 	      return build_server_header (response, ERR_WITH_MSG, tmp);
 	    }
@@ -2730,10 +2729,9 @@ int ext_get_mon_statistic (Json::Value &request, Json::Value &response)
     }
 }
 
-static int num_word (string str)
+static int count_and_get_last_word (string str, char *word)
 {
   stringstream ss(str);
-  string word;
   int count = 0;
 
   while (ss >> word)

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1415,6 +1415,19 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
           return build_server_header (response, ERR_WITH_MSG, tmp);
 	}
 
+      if (conf_item[6].c_str()[0] == 'i')
+	{
+          char tmp[DBMT_ERROR_MSG_SIZE];
+	  int interval = atoi (conf_item[6].c_str()[1]);
+
+	  if (interval <= 0)
+	    {
+	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", conf_item[6].c_str());
+	      tmp_file.close();
+	      return build_server_header (response, ERR_WITH_MSG, tmp);
+	    }
+	}
+
       // get sql script, checking its length
       sql_script = queryplan[index]["query_string"].asString();
       if (sql_script.length() == 0 || sql_script.length() > MAX_AUTOQUERY_SCRIPT_SIZE)

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -86,6 +86,8 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
   {NULL, 0, NULL, 0}
 };
 
+static int num_word (string str);
+
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
 {
@@ -1405,6 +1407,14 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
+      if (num_word (conf_item[6]) < 2)
+	{
+          char tmp[DBMT_ERROR_MSG_SIZE];
+          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIME (at least 2 words expected): %s", conf_item[6].c_str());
+          tmp_file.close();
+          return build_server_header (response, ERR_WITH_MSG, tmp);
+	}
+
       if (conf_item[6].c_str()[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
@@ -2718,4 +2728,18 @@ int ext_get_mon_statistic (Json::Value &request, Json::Value &response)
     {
       return build_server_header (response, ERR_WITH_MSG, errmsg.c_str());
     }
+}
+
+static int num_word (string str)
+{
+  stringstream ss(str);
+  string word;
+  int count = 0;
+
+  while (ss >> word)
+    {
+      count++;
+    }
+
+  return count;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -87,6 +87,7 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
 };
 
 static int num_word (string str);
+static int is_positive_number (const char *str);
 
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
@@ -1418,10 +1419,10 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       if (conf_item[6].c_str()[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
-	  string interval = conf_iterm[6];
+	  string interval = conf_item[6];
 
 	  interval.erase (0, 1);
-	  if (atoi(interval.c_str()) <= 0)
+	  if (is_positive_number (interval.c_str()))
 	    {
 	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", conf_item[6].c_str());
 	      tmp_file.close();
@@ -2742,4 +2743,26 @@ static int num_word (string str)
     }
 
   return count;
+}
+
+static int is_positive_number (const char *str)
+{
+  int len, i;
+
+  if (str == NULL)
+    {
+      return 0;
+    }
+
+  len = strlen (str);
+
+  for (i = 0; i < len; i++)
+    {
+      if (!isdigit (str[i]))
+	{
+	  return 0;
+	}
+    }
+
+  return 1;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -87,6 +87,7 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
 };
 
 static int count_and_get_last_word (string str, char *word);
+static int is_invalid_time (char *str);
 
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
@@ -1269,7 +1270,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
   string conf_item[AUTOEXECQUERY_CONF_ENTRY_NUM];
   fstream conf_file;
   ofstream tmp_file;
-  char interval[TOKEN_LENGTH];
+  char detail2[TOKEN_LENGTH];
 
 
   autoexecquery_conf_file[0] = '\0';
@@ -1408,7 +1409,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
-      if (count_and_get_last_word (conf_item[6], interval) != 2)
+      if (count_and_get_last_word (conf_item[6], detail2) != 2)
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
           snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail: %s", conf_item[6].c_str());
@@ -1416,13 +1417,24 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
           return build_server_header (response, ERR_WITH_MSG, tmp);
 	}
 
-      if (interval[0] == 'i')
+      if (detail2[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
 
-	  if (!is_positive_number (&interval[1]))
+	  if (!is_positive_number (&detail2[1]))
 	    {
-	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", interval);
+	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", detail2);
+	      tmp_file.close();
+	      return build_server_header (response, ERR_WITH_MSG, tmp);
+	    }
+	}
+      else
+	{
+          char tmp[DBMT_ERROR_MSG_SIZE];
+
+	  if (is_invalid_time (detail2))
+	    {
+	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time spec: %s", detail2);
 	      tmp_file.close();
 	      return build_server_header (response, ERR_WITH_MSG, tmp);
 	    }
@@ -2749,4 +2761,25 @@ static int count_and_get_last_word (string str, char *word)
   snprintf (word, TOKEN_LENGTH, "%s", token.c_str ());
 
   return count;
+}
+
+static int is_invalid_time (char *str)
+{
+  int hour, minute;
+  char colon;
+  string timestr = str;
+
+  stringstream ss(timestr);
+
+  if (!(ss >> hour >> colon >> minute))
+    {
+      return 1;
+    }
+
+  if (!ss.eof() || colon != ':' || hour < 0 || hour > 23 || minute < 0 || minute > 59)
+    {
+        return 1;
+    }
+
+  return 0;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -87,7 +87,6 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
 };
 
 static int num_word (string str);
-static int is_positive_number (const char *str);
 
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
@@ -1408,7 +1407,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
-      if (num_word (conf_item[6]) < 2 && conf_item[6].c_str()[0] != 'i')
+      if (num_word (conf_item[6]) < 2)
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
           snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIME (at least 2 words expected): %s", conf_item[6].c_str());
@@ -2743,26 +2742,4 @@ static int num_word (string str)
     }
 
   return count;
-}
-
-static int is_positive_number (const char *str)
-{
-  int len, i;
-
-  if (str == NULL || atoi (str) == 0)
-    {
-      return 0;
-    }
-
-  len = strlen (str);
-
-  for (i = 0; i < len; i++)
-    {
-      if (!isdigit (str[i]))
-	{
-	  return 0;
-	}
-    }
-
-  return 1;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -86,8 +86,6 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
   {NULL, 0, NULL, 0}
 };
 
-static int num_word (string str);
-
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
 {
@@ -1407,14 +1405,6 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
-      if (num_word (conf_item[6]) < 2)
-	{
-          char tmp[DBMT_ERROR_MSG_SIZE];
-          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIME (at least 2 words expected): %s", conf_item[6].c_str());
-          tmp_file.close();
-          return build_server_header (response, ERR_WITH_MSG, tmp);
-	}
-
       if (conf_item[6].c_str()[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
@@ -2728,18 +2718,4 @@ int ext_get_mon_statistic (Json::Value &request, Json::Value &response)
     {
       return build_server_header (response, ERR_WITH_MSG, errmsg.c_str());
     }
-}
-
-static int num_word (string str)
-{
-  stringstream ss(str);
-  string word;
-  int count = 0;
-
-  while (ss >> word)
-    {
-      count++;
-    }
-
-  return count;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -86,6 +86,8 @@ static T_EXTEND_TASK_INFO ext_task_info[] =
   {NULL, 0, NULL, 0}
 };
 
+static int num_word (string str);
+
 static bool
 ext_get_id_from_token (const char *token, char token_content[][TOKEN_LENGTH+1])
 {
@@ -1405,6 +1407,14 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       // details of period
       conf_item[6] = queryplan[index]["detail"].asString();
 
+      if (num_word (conf_item[6]) < 2)
+	{
+          char tmp[DBMT_ERROR_MSG_SIZE];
+          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIMEi (at least 2 words expected): %s", conf_item[6].c_str());
+          tmp_file.close();
+          return build_server_header (response, ERR_WITH_MSG, tmp);
+	}
+
       // get sql script, checking its length
       sql_script = queryplan[index]["query_string"].asString();
       if (sql_script.length() == 0 || sql_script.length() > MAX_AUTOQUERY_SCRIPT_SIZE)
@@ -2704,4 +2714,18 @@ int ext_get_mon_statistic (Json::Value &request, Json::Value &response)
     {
       return build_server_header (response, ERR_WITH_MSG, errmsg.c_str());
     }
+}
+
+static int num_word (string str)
+{
+  stringstream ss(str);
+  string word;
+  int count = 0;
+
+  while (ss >> word)
+    {
+      count++;
+    }
+
+  return count;
 }

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1418,9 +1418,10 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       if (conf_item[6].c_str()[0] == 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
-	  int interval = atoi (conf_item[6].c_str()[1]);
+	  string interval = conf_iterm[6];
 
-	  if (interval <= 0)
+	  interval.erase (0, 1);
+	  if (atoi(interval.c_str()) <= 0)
 	    {
 	      snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid interval: %s", conf_item[6].c_str());
 	      tmp_file.close();

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1411,7 +1411,7 @@ int ext_set_autoexec_query (Json::Value &request, Json::Value &response)
       if (num_word (conf_item[6]) < 2 && conf_item[6].c_str()[0] != 'i')
 	{
           char tmp[DBMT_ERROR_MSG_SIZE];
-          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIMEi (at least 2 words expected): %s", conf_item[6].c_str());
+          snprintf (tmp, DBMT_ERROR_MSG_SIZE-1, "Invalid time format in detail AUTO_QUERY_TIME (at least 2 words expected): %s", conf_item[6].c_str());
           tmp_file.close();
           return build_server_header (response, ERR_WITH_MSG, tmp);
 	}

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -3767,3 +3767,26 @@ ut_record_cubrid_utility_log_stdout (const char *msg)
 
   return 0;
 }
+
+int
+is_positive_number (const char *str)
+{
+  int len, i;
+
+  if (str == NULL || atoi (str) == 0)
+    {
+      return 0;
+    }
+
+  len = strlen (str);
+
+  for (i = 0; i < len; i++)
+    {
+      if (!isdigit (str[i]))
+	{
+	  return 0;
+	}
+    }
+
+  return 1;
+}

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -3771,21 +3771,18 @@ ut_record_cubrid_utility_log_stdout (const char *msg)
 int
 is_positive_number (const char *str)
 {
-  int len, i;
+  char *endptr;
+  long num;
 
-  if (str == NULL || atoi (str) == 0)
+  if (str == NULL)
     {
       return 0;
     }
 
-  len = strlen (str);
-
-  for (i = 0; i < len; i++)
+  num = strtol (str, &endptr, 10);
+  if (errno == ERANGE || (endptr != NULL && strlen (endptr) > 0) || num <= 0)
     {
-      if (!isdigit (str[i]))
-	{
-	  return 0;
-	}
+      return 0;
     }
 
   return 1;

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -3779,6 +3779,7 @@ is_positive_number (const char *str)
       return 0;
     }
 
+  errno = 0;
   num = strtol (str, &endptr, 10);
   if (errno == ERANGE || (endptr != NULL && strlen (endptr) > 0) || num <= 0)
     {

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -3781,10 +3781,10 @@ is_positive_number (const char *str)
 
   errno = 0;
   num = strtol (str, &endptr, 10);
-  if (errno == ERANGE || (endptr != NULL && strlen (endptr) > 0) || num <= 0)
+  if (errno == ERANGE || (endptr != NULL && strlen (endptr) > 0) || num <= 0 || num > INT_MAX)
     {
       return 0;
     }
 
-  return 1;
+  return (int) num;
 }

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -173,6 +173,8 @@ int read_from_socket (SOCKET fd, char *buf, int size);
 int write_to_socket (SOCKET fd, const char *buf, int size);
 int is_cmserver_process (int pid, const char *module_name);
 int make_default_env (void);
+int is_positive_number (const char *str);
+
 #if defined(WINDOWS)
 void remove_end_of_dir_ch (char *path);
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26916

**Description**
* fix parsing error during auto job execution loop
* reject the request if the word count of the 'detail' field in autoexecquery is less than 2
("1 12:00", " EVERYDAY 12:30" are fine, reject "12:00" style)