### PR TITLE
[APIS-1084] Add notify-parent workflow for submodule auto-bump

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   notify:
+    if: ${{ github.event.head_commit != null }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
@@ -28,7 +29,7 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
-          TITLE=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          TITLE=${COMMIT_MSG%%$'\n'*}
           PAYLOAD=$(jq -n --arg p "$SUB_PATH" --arg s "$SHA" --arg m "$TITLE" --arg u "$PUSHER" \
             '{event_type:"submodule-bump",client_payload:{submodule_path:$p,sha:$s,commit_message:$m,pusher:$u}}')
           curl -sS -f -X POST \

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,38 @@
+name: Notify parent (submodule bump)
+
+on:
+  push:
+    branches: [develop]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
+          private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
+          owner: CUBRID
+          repositories: cubrid
+
+      - name: Dispatch submodule-bump to CUBRID/cubrid
+        env:
+          GH_TOKEN:   ${{ steps.app-token.outputs.token }}
+          SUB_PATH:   cubridmanager   # parent-side submodule path (this repo is cubrid-manager-server)
+          SHA:        ${{ github.sha }}
+          PUSHER:     ${{ github.actor }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          TITLE=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          PAYLOAD=$(jq -n --arg p "$SUB_PATH" --arg s "$SHA" --arg m "$TITLE" --arg u "$PUSHER" \
+            '{event_type:"submodule-bump",client_payload:{submodule_path:$p,sha:$s,commit_message:$m,pusher:$u}}')
+          curl -sS -f -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/CUBRID/cubrid/dispatches \
+            -d "$PAYLOAD"


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1084

## Purpose
develop이 갱신되면 부모 `CUBRID/cubrid`에 알려 서브모듈 SHA 갱신 PR이 자동으로 생성되도록 합니다. 부모의 수신(receiver) 워크플로와 짝을 이루는 발신(notify) 워크플로를 추가합니다.

## Implementation
 - `.github/workflows/notify-parent.yml` 추가: `push`(develop)에서 동작
 - GitHub App 토큰(owner=`CUBRID`, repositories=`cubrid`) 발급 → `CUBRID/cubrid`로 `repository_dispatch`(event_type: `submodule-bump`) 전송
 - payload: `submodule_path=cubridmanager`, `sha`, `commit_message`(첫 줄), `pusher`

## Remarks
N/A