### PR TITLE
[CBRD-27065] fix error for backupdir when volname is NULL

### DIFF
--- a/docs/api/backupdb.md
+++ b/docs/api/backupdb.md
@@ -17,8 +17,8 @@ The backupdb interface will create a database backup file.
   "token": "cdfb4c5717170c5e237a227a2ceeccc6ae9e10c16754fb85371c0d74fa0d9d577926f07dd201b6aa",
   "dbname": "alatestdb",
   "level": "0",
-  "volname": "alatestdb_backup_lv0",
   "backupdir": "$CUBRID_DATABASES/alatestdb/backup",
+  "volname": "alatestdb_backup_lv0",
   "removelog": "n",
   "check": "y",
   "mt": "0",
@@ -26,3 +26,10 @@ The backupdb interface will create a database backup file.
   "safereplication": "n"
 }
 ```
+## additional information about *backupdir* and *volume*
+* The final backup directory is determined by the **backupdir** and **volname** parameters. <br>
+  - If the value of backupdir is **/tmp/backupdir** and the value of volname is **lv0**,
+  - the final database backup directory becomes **/tmp/backupdir/lv0**.
+* If **volname is omitted**, backupdir is used as the database backup directory.
+* The final backup directory name must be used as the **pathname** for the restoredb API.
+* *volname* can be omitted, but *backupdir* cannot.

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4599,7 +4599,7 @@ ts_backupdb (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  snprintf (backupfilepath, PATH_MAX - 1, "%s/%s", backupdir, volname);
+  snprintf (backupfilepath, PATH_MAX - 1, "%s%s%s", backupdir, volname ? "/" : "", volname ? volname : "");
 
   /* create directory */
   if (access (backupfilepath, F_OK) < 0)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4599,7 +4599,14 @@ ts_backupdb (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  snprintf (backupfilepath, PATH_MAX - 1, "%s%s%s", backupdir, volname ? "/" : "", volname ? volname : "");
+  if (volname != NULL)
+    {
+      snprintf (backupfilepath, PATH_MAX, "%s/%s", backupdir, volname);
+    }
+  else
+    {
+      snprintf (backupfilepath, PATH_MAX, "%s", backupdir);
+    }
 
   /* create directory */
   if (access (backupfilepath, F_OK) < 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27065

**Description**
* volname이 없는 경우 ${backupdir}/(NULL) 형태의 directory에 backupdb 파일 생성되는 오류 수정