### PR TITLE
[CBRD-26918] checking task permissions for CMS users

### DIFF
--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -2584,6 +2584,7 @@ bool ext_ut_validate_auth (Json::Value &request)
   T_USER_AUTH auth_user = 0;
   T_DBMT_USER dbmt_user;
   T_DBMT_USER_AUTHINFO *auth_info = NULL;
+  T_USER_AUTH current_user_auth = 0;
 
   string task;
   string user_id;
@@ -2637,34 +2638,63 @@ bool ext_ut_validate_auth (Json::Value &request)
 
   for (int index = 0; index < num_authinfo; ++index)
     {
+      string auth;
+
       if (!strcmp (auth_info[index].domain, "user_auth"))
         {
           istringstream (string (auth_info[index].auth)) >> auth_user;
           break;
         }
+
+      istringstream (string (auth_info[index].auth)) >> auth;
+      if (strcmp (auth_info[index].domain, "dbcreate") == 0)
+        {
+	  if ((AU_DBC & auth_task) && strcmp (auth.c_str (), "admin") == 0)
+	    {
+	      current_user_auth |= AU_DBC | AU_DBO;
+	    }
+
+	  if ((AU_DBO & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+	    {
+	      current_user_auth |= AU_DBO;
+	    }
+        }
+
+      if ((AU_BRK & auth_task) && strcmp (auth_info[index].domain, "unicas") == 0)
+        {
+	  if (strcmp (auth.c_str (),"admin") == 0)
+	    {
+	      current_user_auth |= AU_BRK | AU_MON;
+	    }
+
+	  if ((AU_BRK & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+	    {
+	      current_user_auth |= AU_MON;
+	    }
+        }
+
+      if (!strcmp (auth_info[index].domain, "statusmonitorauth"))
+        {
+	  if ((AU_JOB & auth_task) && strcmp (auth.c_str (), "admin") == 0)
+	    {
+	      current_user_auth |= AU_JOB | AU_VAR;
+	    }
+
+	  if ((AU_VAR & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+	    {
+	      current_user_auth |= AU_VAR;
+	    }
+        }
     }
 
   dbmt_user_free (&dbmt_user);
-
-  // assign default authority to old users.
-  if (auth_user == 0)
-    {
-      if (user_id == "admin")
-        {
-          auth_user = AU_ADMIN;
-        }
-      else
-        {
-          auth_user = ALL_AUTHORITY;
-        }
-    }
 
   if (auth_user == AU_ADMIN)
     {
       return true;
     }
 
-  return (auth_user & auth_task) ? true : false;
+  return (current_user_auth & auth_task) ? true : false;
 }
 
 int ext_get_mon_interval (Json::Value &request, Json::Value &response)

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -2641,41 +2641,49 @@ bool ext_ut_validate_auth (Json::Value &request)
       string auth;
 
       if (!strcmp (auth_info[index].domain, "user_auth"))
-        {
-          istringstream (string (auth_info[index].auth)) >> auth_user;
-          break;
-        }
+	{
+	  istringstream (string (auth_info[index].auth)) >> auth_user;
+	  continue;
+	}
 
       istringstream (string (auth_info[index].auth)) >> auth;
-      if (strcmp (auth_info[index].domain, "dbcreate") == 0)
-        {
-	  if ((AU_DBC & auth_task) && strcmp (auth.c_str (), "admin") == 0)
+
+      if (strcmp (auth_info[index].domain, "dbcreate") == 0 || strcmp (auth_info[index].domain, "dbc") == 0)
+	{
+	  if (((AU_DBC | AU_DBO) & auth_task) && strcmp (auth.c_str (), "admin") == 0)
 	    {
 	      current_user_auth |= AU_DBC | AU_DBO;
 	    }
 
-	  if ((AU_DBO & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+	  // assign default authority to old users.
+	  if (auth_user == 0)
 	    {
-	      current_user_auth |= AU_DBO;
+	      if (user_id == "admin")
+		{
+		  if ((AU_DBO & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+		    {
+		      current_user_auth |= AU_DBO;
+		    }
+		}
 	    }
-        }
-
-      if ((AU_BRK & auth_task) && strcmp (auth_info[index].domain, "unicas") == 0)
-        {
-	  if (strcmp (auth.c_str (),"admin") == 0)
+	}
+      else if (((AU_BRK | AU_MON) & auth_task)
+	       && (strcmp (auth_info[index].domain, "unicas") == 0 || strcmp (auth_info[index].domain, "brk") == 0))
+	{
+	  if (strcmp (auth.c_str (), "admin") == 0)
 	    {
 	      current_user_auth |= AU_BRK | AU_MON;
 	    }
 
-	  if ((AU_BRK & auth_task) && strcmp (auth.c_str (), "monitor") == 0)
+	  if (strcmp (auth.c_str (), "monitor") == 0)
 	    {
 	      current_user_auth |= AU_MON;
 	    }
-        }
-
-      if (!strcmp (auth_info[index].domain, "statusmonitorauth"))
-        {
-	  if ((AU_JOB & auth_task) && strcmp (auth.c_str (), "admin") == 0)
+	}
+      else if (strcmp (auth_info[index].domain, "statusmonitorauth") == 0
+	       || strcmp (auth_info[index].domain, "job") == 0 || strcmp (auth_info[index].domain, "var") == 0)
+	{
+	  if (((AU_JOB | AU_VAR) & auth_task) && strcmp (auth.c_str (), "admin") == 0)
 	    {
 	      current_user_auth |= AU_JOB | AU_VAR;
 	    }
@@ -2684,7 +2692,7 @@ bool ext_ut_validate_auth (Json::Value &request)
 	    {
 	      current_user_auth |= AU_VAR;
 	    }
-        }
+	}
     }
 
   dbmt_user_free (&dbmt_user);
@@ -2692,6 +2700,11 @@ bool ext_ut_validate_auth (Json::Value &request)
   if (auth_user == AU_ADMIN)
     {
       return true;
+    }
+
+  if (auth_user != 0)
+    {
+      return (auth_user & auth_task) ? true : false;
     }
 
   return (current_user_auth & auth_task) ? true : false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26918

**Description**
* Check to ensure only CMS APIs allowed to the user are executed
* ASIS: all users can execute all APIs.
* TOBE: only APIs associated with the permissions granted during CMS user creation can be executed. 

**Remarks** (현재 상태)
* ext_ut_validate_auth () at cm_server_extend_interface.cpp 의 comment를 보면
`// assign default authority to old users.`
* user_id가 
  * 'admin' 인 경우 user authority를 AU_ADMIN 으로 할당
  * 이외의 user인 경우 user authority를 ALL_AUTHORITY 으로 할당하여 모두 pass
* 결과적으로 여기서 말하는 old user들 때문에 user authority check가 무력화되어 있다.