### PR TITLE
[CBRD-26577] fix coredump by invalid memory free

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -7135,11 +7135,10 @@ ts_get_tran_info (nvplist *req, nvplist *res, char *_dbmt_error)
   int retval = 0;
   int tmp = 0;
   T_DB_SERVICE_MODE db_mode;
-  char *sqltext;
   int num_queries = 0;
   char *query_p = NULL;
   int query_file_size;
-  TS_SQL_INFO *sql_info;
+  TS_SQL_INFO *sql_info = NULL;
   int has_comma[]={0, 0, 0, 0, 0, 0, 0, 1, 0};
 
   cmd_name[0] = '\0';


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26577

**Description**
* fix coredump by invalid memory free (into develop branch)
* apply [#115](https://github.com/CUBRID/cubrid-manager-server/pull/115) into develop (**applied feature/webmanager** already)

**Remarks**
* 특이한 사항은 이 issue가 cubridmanager가 release build된 경우는 발생하지 않았다는 점.
  (cubridmanager가 debug build 되었을 때 발생함)
* 이로 인해서 아래 2개의 testcase에서 coredump 발생하며 fail 되는 것으로 추정됨
  * shell/_39_fig_cake/cbrd_25693/cases
  * shell/_06_issues/_25_1h/cbrd_26020/cases/
 * 사소한 수정이며 feature/webmanager branch에 반영되며 review 되었기 때문에 빠르게 merge 예정입니다.
