### PR TITLE
[CBRD-26777] just do filename check and allow path outside CUBRID for volume related APIs

### DIFF
--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -2521,7 +2521,7 @@ tsCreateDB (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   else
     {
-      if (!is_authorized_filename (genvolpath, _dbmt_error))
+      if (is_invalid_filename_with_msg (genvolpath, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
 	}
@@ -2540,7 +2540,7 @@ tsCreateDB (nvplist *req, nvplist *res, char *_dbmt_error)
 	}
       else
 	{
-	  if (!is_authorized_filename (logvolpath, _dbmt_error))
+	  if (is_invalid_filename_with_msg (logvolpath, _dbmt_error))
 	    {
 	      return ERR_WITH_MSG;
 	    }
@@ -3151,7 +3151,7 @@ tsRenameDB (nvplist *req, nvplist *res, char *_dbmt_error)
     }
 
   if (exvolpath != NULL && strcmp (exvolpath, "none") != 0 &&
-      !is_authorized_filename (exvolpath, _dbmt_error))
+      is_invalid_filename_with_msg (exvolpath, _dbmt_error))
     {
       return ERR_WITH_MSG;
     }
@@ -3556,7 +3556,7 @@ tsRunAddvoldb (nvplist *req, nvplist *res, char *_dbmt_error)
       volpath = db_dir;
     }
 
-  if (!is_authorized_filename (volpath, _dbmt_error))
+  if (is_invalid_filename_with_msg (volpath, _dbmt_error))
     {
       return ERR_WITH_MSG;
     }
@@ -3713,9 +3713,9 @@ ts_copydb (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
-  if (!is_authorized_filename (logpath, _dbmt_error) ||
-      (destdbpath != NULL && !is_authorized_filename (destdbpath, _dbmt_error)) ||
-      (exvolpath != NULL && !is_authorized_filename (exvolpath, _dbmt_error)))
+  if (is_invalid_filename_with_msg (logpath, _dbmt_error) ||
+      (destdbpath != NULL && is_invalid_filename_with_msg (destdbpath, _dbmt_error)) ||
+      (exvolpath != NULL && is_invalid_filename_with_msg (exvolpath, _dbmt_error)))
     {
       return ERR_WITH_MSG;
     }
@@ -4773,7 +4773,7 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
       snprintf (fullpath, sizeof (fullpath) - 1, "%s", targetdir);
     }
 
-  if (!is_authorized_filename (fullpath, _dbmt_error))
+  if (is_invalid_filename_with_msg (fullpath, _dbmt_error))
     {
       return ERR_WITH_MSG;
     }
@@ -4851,7 +4851,7 @@ ts_unloaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if ((usehash != NULL) && (strcmp (usehash, "yes") == 0))
     {
-      if (strcmp (hashdir, "none") != 0 && !is_authorized_filename (hashdir, _dbmt_error))
+      if (strcmp (hashdir, "none") != 0 && is_invalid_filename_with_msg (hashdir, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
 	}
@@ -5377,7 +5377,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (schema_file_list != NULL && !uStringEqual (schema_file_list, "none"))
     {
-      if (!is_authorized_filename (schema_file_list, _dbmt_error) ||
+      if (is_invalid_filename_with_msg (schema_file_list, _dbmt_error) ||
 	  is_invalid_schema_file_lists (schema_file_list, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
@@ -5544,7 +5544,7 @@ ts_restoredb (nvplist *req, nvplist *res, char *_dbmt_error)
   argv[argc++] = lv;
   if (pathname != NULL && !uStringEqual (pathname, "none"))
     {
-      if (!is_authorized_filename (pathname, _dbmt_error))
+      if (is_invalid_filename_with_msg (pathname, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
 	}
@@ -5559,7 +5559,7 @@ ts_restoredb (nvplist *req, nvplist *res, char *_dbmt_error)
   if (recovery_path != NULL && !uStringEqual (recovery_path, "")
       && !uStringEqual (recovery_path, "none"))
     {
-      if (!is_authorized_filename (recovery_path, _dbmt_error))
+      if (is_invalid_filename_with_msg (recovery_path, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
 	}
@@ -5660,7 +5660,7 @@ ts_backup_vol_info (nvplist *req, nvplist *res, char *_dbmt_error)
     }
   if (pathname != NULL && !uStringEqual (pathname, "none"))
     {
-      if (!is_authorized_filename (pathname, _dbmt_error))
+      if (is_invalid_filename_with_msg (pathname, _dbmt_error))
 	{
 	  return ERR_WITH_MSG;
 	}

--- a/server/src/cm_server_extend_interface.cpp
+++ b/server/src/cm_server_extend_interface.cpp
@@ -1197,12 +1197,12 @@ int ext_read_private_data (Json::Value &request, Json::Value &response)
 
   confname= request["confname"].asString();
 
-  if (!is_authorized_filename (confname.c_str (), _dbmt_error))
+  snprintf (conf_path, PATH_MAX, "%s/%s/%s", sco.szCubrid, DBMT_LOG_DIR, confname.c_str());
+
+  if (!is_authorized_filename (conf_path, _dbmt_error))
     {
       return build_server_header (response, ERR_FILE_OPEN_FAIL, _dbmt_error);
     }
-
-  snprintf (conf_path, PATH_MAX, "%s/%s/%s", sco.szCubrid, DBMT_LOG_DIR, confname.c_str());
 
   infile = fopen (conf_path, "r");
   if (infile == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26577

**Description**
* replace is_authorized_filename () to is_invalid_filename_with_msg so users can create volume/backup files outside $CUBRID, $CUBRID_DATABASES

**Remarks**
**`is_authorized_filename()`을 호출하는 함수 (20개, 총 21회 호출)**

- `_get_confpath_by_name` (static)
- `ts_set_backup_info`
- `ts_add_backup_info`
- `ts_view_log`
- `ts_reset_log`
- `ts_check_dir`
- `ts_check_file`
- `ts_analyzecaslog`
- `ts_executecasrunner`
- `ts_getcaslogtopresult`
- `ts_remove_log`
- `ts_copy_folder` (2회 호출: src_dir, dest_dir 각각)
- `ts_delete_folder`
- `ts_write_and_save_conf`
- `ts_run_sql_statement`
- `ts_get_folders_with_keyword`
- `ts_run_script`
- `ts_get_file_total_line_num`
- `ts_error_trace`
- `ts_remove_files`
- `ts_list_dir`

**`is_invalid_filename_with_msg()`을 호출하는 함수 (9개, 총 13회 호출)**

- `tsCreateDB` (2회: genvolpath, logvolpath)
- `tsRenameDB` (1회: exvolpath)
- `tsRunAddvoldb` (1회: volpath)
- `ts_copydb` (3회: logpath, destdbpath, exvolpath)
- `ts_unloaddb` (2회: fullpath, hashdir)
- `ts_backupdb` (1회: backupfilepath)
- `ts_loaddb` (1회: schema_file_list)
- `ts_restoredb` (2회: pathname, recovery_path)
- `ts_backup_vol_info` (1회: pathname)
