### PR TITLE
[CBRD-26915] add new key input-class-file to enable -i option on compactdb

### DIFF
--- a/docs/api/compactdb.md
+++ b/docs/api/compactdb.md
@@ -10,8 +10,8 @@ Compact database.
 | token | token string encrypted. |
 | dbname | database name |
 | verbose | on-off indicating whether to show detailed information |
-| input-class-file | path of a file that lists the classes to compact, one class name per line. passed to compactdb as `-i <file>`. cannot be given together with class-names |
-| class-names | a list of class names to compact. the server writes the names to a temporary file and passes it to compactdb the same way input-class-file does. cannot be given together with input-class-file |
+| input-class-file | path of a file that lists the classes to compact, one class name per line. cannot be given together with class-names |
+| class-names | a list of class names to compact. cannot be given together with input-class-file |
 
 ## Request Sample
 

--- a/docs/api/compactdb.md
+++ b/docs/api/compactdb.md
@@ -10,6 +10,8 @@ Compact database.
 | token | token string encrypted. |
 | dbname | database name |
 | verbose | on-off indicating whether to show detailed information |
+| input-class-file | path of a file that lists the classes to compact, one class name per line. passed to compactdb as `-i <file>`. cannot be given together with class-names |
+| class-names | a list of class names to compact. the server writes the names to a temporary file and passes it to compactdb the same way input-class-file does. cannot be given together with input-class-file |
 
 ## Request Sample
 
@@ -18,7 +20,19 @@ Compact database.
   "task":"compactdb",
   "token":"cdfb4c5717170c5e9c6856b4d1c61ee8132bcc7d82bd609066ed9ece2554c47f7926f07dd201b6aa",
   "dbname":"alatestdb",
-  "input-class-file":"$CUBRID/tmp/demodb-input-class-file",
+  "input-class-file":"$CUBRID/tmp/alatestdb-input-class-file",
+  "verbose":"y"
+}
+```
+
+`class-names` can be used instead of `input-class-file` when the caller wants to specify the target classes directly, without preparing a file itself:
+
+```
+{
+  "task":"compactdb",
+  "token":"cdfb4c5717170c5e9c6856b4d1c61ee8132bcc7d82bd609066ed9ece2554c47f7926f07dd201b6aa",
+  "dbname":"alatestdb",
+  "class-names":["public.athlete", "public.event", "public.history"],
   "verbose":"y"
 }
 ```

--- a/docs/api/compactdb.md
+++ b/docs/api/compactdb.md
@@ -18,6 +18,7 @@ Compact database.
   "task":"compactdb",
   "token":"cdfb4c5717170c5e9c6856b4d1c61ee8132bcc7d82bd609066ed9ece2554c47f7926f07dd201b6aa",
   "dbname":"alatestdb",
+  "input-class-file":"$CUBRID/tmp/demodb-input-class-file",
   "verbose":"y"
 }
 ```

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -373,6 +373,7 @@
 #define COMPACT_SA_MODE_L                       "SA-mode"
 #define COMPACT_CS_MODE_S                       'C'
 #define COMPACT_CS_MODE_L                       "CS-mode"
+#define COMPACT_INPUT_CLASS_FILE_S              "i"
 
 /* paramdump option list */
 #define PARAMDUMP_BOTH_S                        'b'

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -367,6 +367,7 @@ static int schema_file_not_exist (const char *schema_list_file, char *_dbmt_erro
 static int expand_path (const char *src, char *dst, int dest_len);
 
 static int is_ha_updates_disabled (char *dbname, char *_dbmt_error);
+static int create_input_class_file (nvplist *req, nvplist *res, const char *filename, char *_dbmt_error);
 
 static char *allowed_env[]=
 {
@@ -4424,12 +4425,64 @@ statdump_finale:
   return retval;
 }
 
+/*
+ * create_input_class_file () - write the "class-names" values of req to
+ *   filename, one class name per line, so the resulting file can be
+ *   handed to compactdb the same way a user supplied "input-class-file"
+ *   is.
+ *
+ *   req (in)   : client request.
+ *   res (in)   : client response
+ *   filename (in) : path of the temporary file to create.
+ *   _dbmt_error (out) : error message buffer.
+ *
+ *   return : ERR_NO_ERROR on success, an ERR_ code on failure.
+ */
+static int
+create_input_class_file (nvplist *req, nvplist *res, const char *filename, char *_dbmt_error)
+{
+  int i;
+  char *name = NULL;
+  char *value = NULL;
+  int class_cnt = 0;
+  FILE *fp;
+
+  fp = fopen (filename, "w");
+  if (fp == NULL)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "%s", filename);
+      return ERR_TMPFILE_OPEN_FAIL;
+    }
+
+  for (i = 0; i < req->nvplist_leng; i++)
+    {
+      nv_lookup (req, i, &name, &value);
+      if ((name != NULL) && (strcmp (name, "class-names") == 0) && (value != NULL) && (value[0] != '\0'))
+	{
+	  fprintf (fp, "%s\n", value);
+	  class_cnt++;
+	}
+    }
+
+  fclose (fp);
+
+  if (class_cnt == 0)
+    {
+      unlink (filename);
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "%s", "class-names");
+      return ERR_PARAM_MISSING;
+    }
+
+  return ERR_NO_ERROR;
+}
+
 int
 ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
 {
   char cmd_name[CUBRID_CMD_NAME_LEN];
   char out_file[PATH_MAX];
   char err_file[PATH_MAX];
+  char class_names_file[PATH_MAX];
   char dbname_at_hostname[MAXHOSTNAMELEN + DB_NAME_LEN];
 
   const char *argv[10];
@@ -4441,6 +4494,7 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
   int retval = ERR_NO_ERROR;
   int createtmpfile = 0;
   char *input_class_file = NULL;
+  char *class_names = NULL;
 
   char *dbname = NULL;
   char *verbose = NULL;
@@ -4448,6 +4502,7 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
   cmd_name[0] = '\0';
   out_file[0] = '\0';
   err_file[0] = '\0';
+  class_names_file[0] = '\0';
 
   dbname = nv_get_val (req, "dbname");
   if (dbname == NULL)
@@ -4502,11 +4557,37 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
     }
 
   input_class_file = nv_get_val (req, "input-class-file");
+  class_names = nv_get_val (req, "class-names");
+
+  if (input_class_file != NULL && class_names != NULL)
+    {
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "Use only one of the two keys: 'input-class-file' or 'class-names'");
+      return ERR_WITH_MSG;
+    }
+
+
+  if (class_names != NULL)
+    {
+      make_temp_filepath (class_names_file, sco.dbmt_tmp_dir, "compactdb_input_class", TS_COMPACTDB, PATH_MAX);
+
+      retval = create_input_class_file (req, res, class_names_file, _dbmt_error);
+      if (retval != ERR_NO_ERROR)
+	{
+	  return retval;
+	}
+
+      input_class_file = class_names_file;
+    }
+
   if (input_class_file)
     {
       if (access (input_class_file, F_OK) < 0)
         {
           snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "input-class_file does not exists: %s", input_class_file);
+          if (class_names != NULL)
+	    {
+	      unlink (class_names_file);
+	    }
           return ERR_WITH_MSG;
         }
 
@@ -4564,6 +4645,10 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
 rm_tmpfile:
   unlink (out_file);
   unlink (err_file);
+  if (class_names != NULL)
+    {
+      unlink (class_names_file);
+    }
   return retval;
 }
 

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4571,12 +4571,20 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
       make_temp_filepath (class_names_file, sco.dbmt_tmp_dir, "compactdb_input_class", TS_COMPACTDB, PATH_MAX);
 
       retval = create_input_class_file (req, res, class_names_file, _dbmt_error);
-      if (retval != ERR_NO_ERROR)
+      if (retval == ERR_TMPFILE_OPEN_FAIL)
 	{
 	  return retval;
 	}
+      else if (retval == ERR_NO_ERROR)
+	{
+	  input_class_file = class_names_file;
+	}
+      else
+	{
+	  unlink (class_names_file);
+	  class_names = NULL;
+	}
 
-      input_class_file = class_names_file;
     }
 
   if (input_class_file)

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -4440,6 +4440,7 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
   int argc = 0;
   int retval = ERR_NO_ERROR;
   int createtmpfile = 0;
+  char *input_class_file = NULL;
 
   char *dbname = NULL;
   char *verbose = NULL;
@@ -4498,6 +4499,19 @@ ts_compactdb (nvplist *req, nvplist *res, char *_dbmt_error)
 	{
 	  return ERR_WITH_MSG;
 	}
+    }
+
+  input_class_file = nv_get_val (req, "input-class-file");
+  if (input_class_file)
+    {
+      if (access (input_class_file, F_OK) < 0)
+        {
+          snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "input-class_file does not exists: %s", input_class_file);
+          return ERR_WITH_MSG;
+        }
+
+      argv[argc++] = "-" COMPACT_INPUT_CLASS_FILE_S;
+      argv[argc++] = input_class_file;
     }
 
   snprintf (dbname_at_hostname, sizeof (dbname_at_hostname), "%s%s", dbname, ha_mode ? "@localhost" : "");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26915

**Description**
* add new key '**input-class-file**', **class-names**
* value of the key input-class-file is the filename containing the names of the classes targeted by compactdb
* value of the **class-names** are the names of the classes to which compactdb will be performed.
* **both input-class-file and class-names cannot be used together**
* if both 'input-class-file' and class-names are omitted or the value is NULL, compactdb will be executed for the entire classes.
* request sample1: to enable -i option
```
{
  "task":"compactdb",
  "dbname":"demodb",
  "input-class-file":"$CUBRID/tmp/input-class-file",
  "verbose":"y"
}
```
```
{
  "task": "compactdb",
  "dbname": "demodb",
  "class-names": ["public.athlete", "public.event", "public.history"],
  "verbose": "y"
}
```