### PR TITLE
[CBRD-26861] async interface for time-consuming APIs

### DIFF
--- a/docs/api/addvoldb.md
+++ b/docs/api/addvoldb.md
@@ -12,6 +12,9 @@ Add a new volume.
 | volname | volume name |
 | purpose | generic, data, index, temp |
 | size_need_mb | size of the volume in megabytes (MB) |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -21,7 +24,8 @@ Add a new volume.
   "dbname":"demodb",
   "volname":"testvol",
   "purpose":"generic",
-  "size_need_mb":"500"
+  "size_need_mb":"500",
+  "async":"yes"
 }
 ```
 
@@ -41,5 +45,16 @@ Add a new volume.
   "note": "none",
   "status": "success",
   "task": "addvoldb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "addvoldb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/addvoldb.md
+++ b/docs/api/addvoldb.md
@@ -54,7 +54,6 @@ Add a new volume.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "addvoldb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/backupdb.md
+++ b/docs/api/backupdb.md
@@ -44,7 +44,6 @@ The backupdb interface will create a database backup file.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "backupdb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/backupdb.md
+++ b/docs/api/backupdb.md
@@ -8,6 +8,9 @@ The backupdb interface will create a database backup file.
 | --- | --- |
 | task | task name |
 | token | token string encrypted. |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -23,7 +26,8 @@ The backupdb interface will create a database backup file.
   "check": "y",
   "mt": "0",
   "zip": "y",
-  "safereplication": "n"
+  "safereplication": "n",
+  "async":"yes"
 }
 ```
 ## additional information about *backupdir* and *volume*
@@ -33,3 +37,14 @@ The backupdb interface will create a database backup file.
 * If **volname is omitted**, backupdir is used as the database backup directory.
 * The final backup directory name must be used as the **pathname** for the restoredb API.
 * *volname* can be omitted, but *backupdir* cannot.
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "backupdb",
+   "uuid" : "14"
+}
+```

--- a/docs/api/checkdb.md
+++ b/docs/api/checkdb.md
@@ -10,6 +10,9 @@ Check consistency of database.
 | token | token string encrypted. |
 | dbname | database name |
 | repairdb | on-off indicating whether to repair database |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -18,7 +21,8 @@ Check consistency of database.
   "task": "checkdb",
   "token": "cdfb4c5717170c5e237a227a2ceeccc6ae9e10c16754fb85371c0d74fa0d9d577926f07dd201b6aa",
   "dbname": "alatestdb",
-  "repairdb": "n"
+  "repairdb": "n",
+  "async":"yes"
 }
 ```
 
@@ -39,5 +43,16 @@ Check consistency of database.
    "note" : "none",
    "status" : "success",
    "task" : "checkdb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "checkdb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/checkdb.md
+++ b/docs/api/checkdb.md
@@ -52,7 +52,6 @@ Check consistency of database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "checkdb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/compactdb.md
+++ b/docs/api/compactdb.md
@@ -66,7 +66,6 @@ Compact database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "compactdb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/compactdb.md
+++ b/docs/api/compactdb.md
@@ -12,6 +12,9 @@ Compact database.
 | verbose | on-off indicating whether to show detailed information |
 | input-class-file | path of a file that lists the classes to compact, one class name per line. cannot be given together with class-names |
 | class-names | a list of class names to compact. cannot be given together with input-class-file |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -21,7 +24,8 @@ Compact database.
   "token":"cdfb4c5717170c5e9c6856b4d1c61ee8132bcc7d82bd609066ed9ece2554c47f7926f07dd201b6aa",
   "dbname":"alatestdb",
   "input-class-file":"$CUBRID/tmp/alatestdb-input-class-file",
-  "verbose":"y"
+  "verbose":"y",
+  "async":"yes"
 }
 ```
 
@@ -53,5 +57,16 @@ Compact database.
    "note" : "none",
    "status" : "success",
    "task" : "compactdb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "compactdb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/copydb.md
+++ b/docs/api/copydb.md
@@ -62,7 +62,6 @@ Copy database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "copydb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/copydb.md
+++ b/docs/api/copydb.md
@@ -15,6 +15,9 @@ Copy database.
 | overwrite | on-off indicating whether to replace existing database |
 | move | on-off indicating whether to remove existing database |
 | advanced | on-off indicating whether to offer local control files |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -29,7 +32,8 @@ Copy database.
   "logpath":"$CUBRID_DATABASES/destinationdb",
   "overwrite":"y",
   "move":"n",
-  "advanced":"off"
+  "advanced":"off",
+  "async":"yes"
 }
 ```
 
@@ -49,5 +53,16 @@ Copy database.
    "note" : "none",
    "status" : "success",
    "task" : "copydb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "copydb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/createdb.md
+++ b/docs/api/createdb.md
@@ -16,6 +16,9 @@ Create database.
 | logvolpath | log volume path |
 | exvol | extend volume information |
 | charset | language and charset, ex. en_US.iso88591, ko_KR.utf8. please refer to $CUBRID/conf/cubrid_locales.all.txt |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -32,7 +35,8 @@ Create database.
    "logvolpath":"$CUBRID_DATABASES/alatestdb",
    "exvol":{"alatestdb_data_x001":"data;100;$CUBRID_DATABASES/alatestdb"},
    "charset":"en_US.utf8",
-   "overwrite_config_file":"YES"
+   "overwrite_config_file":"YES",
+  "async":"yes"
  }
 ```
 
@@ -55,4 +59,13 @@ Create database.
 }
 ```
 
-
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "createdb",
+   "uuid" : "14"
+}
+```

--- a/docs/api/createdb.md
+++ b/docs/api/createdb.md
@@ -65,7 +65,6 @@ Create database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "createdb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/gettaskstatus.md
+++ b/docs/api/gettaskstatus.md
@@ -10,6 +10,8 @@ Check the status of a task asynchronously running
 | token | token string encrypted. |
 | uuid | uuid from the asynchronous task response |
 
+* an async job is dropped 3,600 seconds after it was created by default,<br>
+ it can be cnahged in cm.conf, for example "async_job_ttl_sec=7200"
 
 ## Request Sample
 

--- a/docs/api/gettaskstatus.md
+++ b/docs/api/gettaskstatus.md
@@ -1,0 +1,74 @@
+# gettaskstatus
+
+Check the status of a task asynchronously running
+
+## Request JSON Syntax
+
+| **Key** | **Description** |
+| --- | --- |
+| task | task name |
+| token | token string encrypted. |
+| uuid | uuid from the asynchronous task response |
+
+
+## Request Sample
+
+```
+{
+  "task": "gettaskstatus",
+  "token": "cdfb4c5717170c5e237a227a2ceeccc6ae9e10c16754fb85371c0d74fa0d9d577926f07dd201b6aa",
+  "uuid":"$UUID"
+}
+```
+
+## Response JSON Syntax
+
+| **Key** | **Description** |
+| --- | --- |
+| job-status | one of running, success, error |
+| status | execution result, success or failed. |
+| note | if failed, a brief description will be given here |
+| uuid | uuid given in the request |
+
+
+## Response Sample if task is running
+
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "uuid" : "14"
+}
+```
+
+## Response Sample if task is completed successfully
+```
+{
+   "__EXEC_TIME" : "66860 ms",
+   "job-status" : "success",
+   "note" : "none",
+   "status" : "success",
+   "task" : "createdb",
+   "uuid" : "14"
+}
+```
+## Response Sample if task is completed with error
+```
+{
+   "__EXEC_TIME" : "26 ms",
+   "job-status" : "error",
+   "note" : "Couldn't create database.<end>Database \"testdb\" already exists.<end>",
+   "status" : "failure",
+   "task" : "createdb",
+   "uuid" : "14"
+}
+```
+
+## Response Sample with invalid uuid
+```
+{
+   "note" : "invalid uuid",
+   "status" : "failure"
+}
+```

--- a/docs/api/loaddb.md
+++ b/docs/api/loaddb.md
@@ -23,6 +23,9 @@ The loaddb interface will load a database from files.
 | no-user-specified-name | Find classes, serials, and triggers by their object names without their owner names |
 | schema-file-list | name of schema-file-list, list of schema file names to be used in loaddb |
 | delete_orignal_files | delete original file after load |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -42,6 +45,18 @@ The loaddb interface will load a database from files.
   "index": "none",
   "errorcontrolfile": "none",
   "ignoreclassfile": "none",
-  "delete_orignal_files": "y"
+  "delete_orignal_files": "y",
+  "async":"yes"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "loaddb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/loaddb.md
+++ b/docs/api/loaddb.md
@@ -56,7 +56,6 @@ The loaddb interface will load a database from files.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "loaddb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/optimizedb.md
+++ b/docs/api/optimizedb.md
@@ -51,7 +51,6 @@ Optimize database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "optimizedb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/optimizedb.md
+++ b/docs/api/optimizedb.md
@@ -10,6 +10,9 @@ Optimize database.
 | token | token string encrypted. |
 | dbname | database name |
 | classname | database table name |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -18,7 +21,8 @@ Optimize database.
   "task": "optimizedb",
   "token": "cdfb4c5717170c5ed30ef86644baf8151531ce5adff4a1f9a54711c51e0f50767926f07dd201b6aa",
   "dbname": "alatestdb",
-  "classname": ""
+  "classname": "",
+  "async":"yes"
 }
 ```
 
@@ -38,5 +42,16 @@ Optimize database.
    "note" : "none",
    "status" : "success",
    "task" : "optimizedb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "optimizedb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/renamedb.md
+++ b/docs/api/renamedb.md
@@ -13,6 +13,9 @@ Rename database.
 | exvolpath | extend volume path |
 | advanced | on-off indicating whether to offer local control files |
 | forcedel | on-off indicating whether to remove backup files |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -25,7 +28,8 @@ Rename database.
   "exvolpath":"none",
   "advanced":"on",
   "volume":{"$CUBRID_DATABASES/destinationdb/destinationdb":"$CUBRID_DATABASES/anotherdb/anotherdb"},
-  "forcedel":"y"
+  "forcedel":"y",
+  "async":"yes"
 }
 ```
 
@@ -45,5 +49,16 @@ Rename database.
   "note": "none",
   "status": "success",
   "task": "renamedb"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "renamedb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/renamedb.md
+++ b/docs/api/renamedb.md
@@ -58,7 +58,6 @@ Rename database.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "renamedb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/restoredb.md
+++ b/docs/api/restoredb.md
@@ -14,6 +14,9 @@ The restoredb interface will restore a database from backup.
 | partial | perform partial recovery if any log archive is absent |
 | pathname | PATH is a directory of backup volumes to be restored |
 | recoverypath | restore the database and log volumes to the path specified in the database location file |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -26,6 +29,18 @@ The restoredb interface will restore a database from backup.
   "level": "0",
   "partial": "y",
   "pathname": "$CUBRID_DATABASES/alatestdb/backup/alatestdb_backup_lv0",
-  "recoverypath": "$CUBRID_DATABASES/alatestdb"
+  "recoverypath": "$CUBRID_DATABASES/alatestdb",
+  "async":"yes"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "restoredb",
+   "uuid" : "14"
 }
 ```

--- a/docs/api/restoredb.md
+++ b/docs/api/restoredb.md
@@ -40,7 +40,6 @@ The restoredb interface will restore a database from backup.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "restoredb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/unloaddb.md
+++ b/docs/api/unloaddb.md
@@ -62,7 +62,6 @@ The unloaddb interface will unload a database server.
    "job-status" : "running",
    "note" : "none",
    "status" : "success",
-   "task" : "unloaddb",
    "uuid" : "14"
 }
 ```

--- a/docs/api/unloaddb.md
+++ b/docs/api/unloaddb.md
@@ -25,6 +25,9 @@ The unloaddb interface will unload a database server.
 | prefix | PREFIX for output files; default: the database name |
 | cache | NUMBER of cached pages; default: 100 |
 | lofile | lo file COUNT per a directory; default: 0 |
+| async | default "no", if "yes" run the task in asynchronous mode |
+
+* The status of a task running in asynchronous mode can be checked using the 'gettaskstatus' api
 
 ## Request Sample
 
@@ -48,6 +51,18 @@ The unloaddb interface will unload a database server.
   "estimate": "none",
   "prefix": "none",
   "cach": "none",
-  "lofile": "none"
+  "lofile": "none",
+  "async":"yes"
+}
+```
+
+## Response Sample (async mode)
+```
+{
+   "job-status" : "running",
+   "note" : "none",
+   "status" : "success",
+   "task" : "unloaddb",
+   "uuid" : "14"
 }
 ```

--- a/server/src/cm_autojob.cpp
+++ b/server/src/cm_autojob.cpp
@@ -737,15 +737,16 @@ set_query_period_details (query_period_details **details, char *conf_item)
   char delim[] = " ,";
   char *token = NULL;
   query_period_details *head = NULL;
+  char *saveptr;
 
-  token = strtok (conf_item, delim);
+  token = STRTOK (conf_item, delim, &saveptr);
   while (token != NULL)
     {
       *details = (query_period_details *) malloc (sizeof (query_period_details));
       strncpy ((*details)->detail, token, DETAIL_LEN);
       (*details)->next = head;
       head = *details;
-      token = strtok (NULL, delim);
+      token = STRTOK (NULL, delim, &saveptr);
     }
 }
 
@@ -755,9 +756,10 @@ set_backup_period_details (backup_period_details **details,
 {
   char delim[] = " ,";
   char *token;
+  char *saveptr;
   backup_period_details *head = NULL;
 
-  token = strtok (conf_item, delim);
+  token = STRTOK (conf_item, delim, &saveptr);
   while (token != NULL)
     {
       *details =
@@ -817,7 +819,7 @@ set_backup_period_details (backup_period_details **details,
 
       (*details)->next = head;
       head = *details;
-      token = strtok (NULL, delim);
+      token = STRTOK (NULL, delim, &saveptr);
     }
 }
 

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -150,13 +150,18 @@ cmd_csql (char *dbname, char *uid, char *passwd, T_CUBRID_MODE mode,
   return res;
 }
 
-void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
+void find_and_parse_cub_admin_version (int &major_version, int &minor_version, char *build_version, size_t build_version_size)
 {
   const char *argv[3];
   char tmpfile[PATH_MAX], strbuf[BUFFER_MAX_LEN];
   FILE *infile;
   char cmd_name[CUBRID_CMD_NAME_LEN];
   char *saveptr;
+
+  if (build_version != NULL && build_version_size > 0)
+    {
+      build_version[0] = '\0';
+    }
 
   cubrid_cmd_name (cmd_name);
   make_temp_filepath (tmpfile, sco.dbmt_tmp_dir, "cub_admin_version", TS_GET_SERVER_VERSION, PATH_MAX);
@@ -169,7 +174,7 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
     {
       if (!fgets (strbuf, sizeof (strbuf), infile) || ! fgets (strbuf, sizeof (strbuf), infile))
         {
-           LOG_ERROR ("Spacedb is skipped due to temporarily insufficient resources");
+           LOG_ERROR ("cubrid --version is skipped due to temporarily insufficient resources");
            major_version = minor_version = -1;
            return;
         }
@@ -180,6 +185,25 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
       major_version = atoi (p);
       p = STRTOK (NULL, ".", &saveptr);
       minor_version = atoi (p);
+
+      if (build_version != NULL && build_version_size > 0)
+        {
+          char *lparen = strchr (strbuf, '(');
+          if (lparen != NULL)
+            {
+              char *rparen = strchr (lparen + 1, ')');
+              if (rparen != NULL && rparen > lparen + 1)
+                {
+                  size_t len = (size_t) (rparen - (lparen + 1));
+                  if (len >= build_version_size)
+                    {
+                      len = build_version_size - 1;
+                    }
+                  strncpy (build_version, lparen + 1, len);
+                  build_version[len] = '\0';
+                }
+            }
+        }
 
       fclose (infile);
       unlink (tmpfile);
@@ -206,7 +230,7 @@ cmd_spacedb (const char *dbname, T_CUBRID_MODE mode)
   if (IS_INVALID_CUBRID_VERS_MAJOR (cubrid_version_major))
     {
       LOG_ERROR ("Invalid CUBRID Engine Version: %d.%d", cubrid_version_major, cubrid_version_minor);
-      find_and_parse_cub_admin_version (major_version, minor_version);
+      find_and_parse_cub_admin_version (major_version, minor_version, cubrid_version_build, sizeof (cubrid_version_build));
       cubrid_version_major = major_version;
       cubrid_version_minor = minor_version;
     }

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -156,6 +156,7 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
   char tmpfile[PATH_MAX], strbuf[BUFFER_MAX_LEN];
   FILE *infile;
   char cmd_name[CUBRID_CMD_NAME_LEN];
+  char *saveptr;
 
   cubrid_cmd_name (cmd_name);
   make_temp_filepath (tmpfile, sco.dbmt_tmp_dir, "cub_admin_version", TS_GET_SERVER_VERSION, PATH_MAX);
@@ -175,9 +176,9 @@ void find_and_parse_cub_admin_version (int &major_version, int &minor_version)
       char version[10];
       sscanf (strbuf, "%*s %s", version);
 
-      char *p = strtok (version, ".");
+      char *p = STRTOK (version, ".", &saveptr);
       major_version = atoi (p);
-      p = strtok (NULL, ".");
+      p = STRTOK (NULL, ".", &saveptr);
       minor_version = atoi (p);
 
       fclose (infile);
@@ -851,19 +852,20 @@ int SpaceDbResultOldFormat::get_volume_info (char *str_buf, SpaceDbVolumeInfoOld
   int volid, total_page, free_page;
   char purpose[COLUMN_VALUE_MAX_SIZE], vol_name[PATH_MAX];
   char *token = NULL, *p;
+  char *saveptr;
   struct stat statbuf;
 
   volid = total_page = free_page = 0;
   purpose[0] = vol_name[0] = '\0';
 
-  token = strtok (str_buf, " ");
+  token = STRTOK (str_buf, " ", &saveptr);
   if (token == NULL)
     {
       return FALSE;
     }
   volid = atoi (token);
 
-  token = strtok (NULL, " ");
+  token = STRTOK (NULL, " ", &saveptr);
   if (token == NULL)
     {
       return FALSE;
@@ -876,7 +878,7 @@ int SpaceDbResultOldFormat::get_volume_info (char *str_buf, SpaceDbVolumeInfoOld
       return FALSE;
     }
 
-  token = strtok (NULL, " ");
+  token = STRTOK (NULL, " ", &saveptr);
   if (token == NULL)
     {
       return FALSE;
@@ -894,7 +896,7 @@ int SpaceDbResultOldFormat::get_volume_info (char *str_buf, SpaceDbVolumeInfoOld
           strcat (purpose, token);
         }
 
-      token = strtok (NULL, " ");
+      token = STRTOK (NULL, " ", &saveptr);
       if (token == NULL)
         {
           return FALSE;
@@ -902,14 +904,14 @@ int SpaceDbResultOldFormat::get_volume_info (char *str_buf, SpaceDbVolumeInfoOld
     }
   total_page = atoi (token);
 
-  token = strtok (NULL, " ");
+  token = STRTOK (NULL, " ", &saveptr);
   if (token == NULL)
     {
       return FALSE;
     }
   free_page = atoi (token);
 
-  token = strtok (NULL, "\n");
+  token = STRTOK (NULL, "\n", &saveptr);
   if (token == NULL)
     {
       return FALSE;

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -267,11 +267,13 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
 
 
   /* unset CUBRID_ERROR_LOG environment variable, using default value */
+  env_mutex_lock ();
 #if defined(WINDOWS)
   _putenv ("CUBRID_ERROR_LOG=");
 #else
   unsetenv ("CUBRID_ERROR_LOG");
 #endif
+  env_mutex_unlock ();
 
   cmd_name[0] = '\0';
 #if !defined (DO_NOT_USE_CUBRIDENV)
@@ -292,13 +294,17 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
 #else /* pa-risc */
   strcpy (jvm_env_string, "LD_PRELOAD=libjvm.sl");
 #endif
+  env_mutex_lock ();
   putenv (jvm_env_string);
+  env_mutex_unlock ();
 #endif
 
   pid = run_child (argv, 1, NULL, stdout_log_file, stderr_log_file, NULL);    /* start server */
 
 #ifdef HPUX
+  env_mutex_lock ();
   putenv ("LD_PRELOAD=");
+  env_mutex_unlock ();
 #endif
 
   if (pid < 0)

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -137,7 +137,7 @@ cmd_csql (char *dbname, char *uid, char *passwd, T_CUBRID_MODE mode,
   {
     const char *extra_envp[] = TRANSACTION_NO_WAIT_MODE_ENVP;
 
-    run_child_env (argv, 1, NULL, NULL, out_file, extra_envp, NULL);    /* csql */
+    run_child_env (argv, 1, NULL, NULL, out_file, NULL, extra_envp);    /* csql */
   }
 
   res = new_csql_result ();
@@ -319,7 +319,7 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
 
   extra_envp[envc] = NULL;
 
-  pid = run_child_env (argv, 1, NULL, stdout_log_file, stderr_log_file, extra_envp, NULL);    /* start server */
+  pid = run_child_env (argv, 1, NULL, stdout_log_file, stderr_log_file, NULL, extra_envp);    /* start server */
 
   if (pid < 0)
     {

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -280,6 +280,8 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
   int ret_val;
   char cmd_name[CUBRID_CMD_NAME_LEN];
   const char *argv[5];
+  const char *extra_envp[3];
+  int envc = 0;
 
 #ifdef HPUX
   char jvm_env_string[32];
@@ -288,16 +290,6 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
   cmd_start_master ();
   make_temp_filepath (stdout_log_file, sco.dbmt_tmp_dir, "cmserverstart", TS_CMSERVERSTART, PATH_MAX);
   make_temp_filepath (stderr_log_file, sco.dbmt_tmp_dir, "cmserverstart2", TS_CMSERVERSTART, PATH_MAX);
-
-
-  /* unset CUBRID_ERROR_LOG environment variable, using default value */
-  env_mutex_lock ();
-#if defined(WINDOWS)
-  _putenv ("CUBRID_ERROR_LOG=");
-#else
-  unsetenv ("CUBRID_ERROR_LOG");
-#endif
-  env_mutex_unlock ();
 
   cmd_name[0] = '\0';
 #if !defined (DO_NOT_USE_CUBRIDENV)
@@ -312,24 +304,20 @@ cmd_start_server (char *dbname, char *err_buf, int err_buf_size)
   argv[3] = dbname;
   argv[4] = NULL;
 
+  extra_envp[envc++] = "CUBRID_ERROR_LOG=";    /* removing env variable CUBRID_ERROR_LOG if exists */
+
 #ifdef HPUX
 #ifdef HPUX_IA64
   strcpy (jvm_env_string, "LD_PRELOAD=libjvm.so");
 #else /* pa-risc */
   strcpy (jvm_env_string, "LD_PRELOAD=libjvm.sl");
 #endif
-  env_mutex_lock ();
-  putenv (jvm_env_string);
-  env_mutex_unlock ();
+  extra_envp[envc++] = jvm_env_string;
 #endif
 
-  pid = run_child (argv, 1, NULL, stdout_log_file, stderr_log_file, NULL);    /* start server */
+  extra_envp[envc] = NULL;
 
-#ifdef HPUX
-  env_mutex_lock ();
-  putenv ("LD_PRELOAD=");
-  env_mutex_unlock ();
-#endif
+  pid = run_child_env (argv, 1, NULL, stdout_log_file, stderr_log_file, extra_envp, NULL);    /* start server */
 
   if (pid < 0)
     {

--- a/server/src/cm_cmd_exec.cpp
+++ b/server/src/cm_cmd_exec.cpp
@@ -134,9 +134,11 @@ cmd_csql (char *dbname, char *uid, char *passwd, T_CUBRID_MODE mode,
 #endif
   make_temp_filepath (cubrid_err_file, sco.dbmt_tmp_dir, "cmd_csql_err", TS_CSQL_CMD, PATH_MAX);
 
-  SET_TRANSACTION_NO_WAIT_MODE_ENV ();
+  {
+    const char *extra_envp[] = TRANSACTION_NO_WAIT_MODE_ENVP;
 
-  run_child (argv, 1, NULL, NULL, out_file, NULL);    /* csql */
+    run_child_env (argv, 1, NULL, NULL, out_file, extra_envp, NULL);    /* csql */
+  }
 
   res = new_csql_result ();
   if (res == NULL)

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -232,6 +232,7 @@ uReadSystemConfig (void)
   int str_len = 0;
   char access_log_buf[PATH_MAX];
   char error_log_buf[PATH_MAX];
+  char *saveptr;
 
   conf_file = fopen (conf_get_dbmt_file (FID_DBMT_CONF, cbuf), "rt");
   if (conf_file == NULL)
@@ -275,7 +276,7 @@ uReadSystemConfig (void)
       * put the first token into var ent_name,
       * the separator is ' ', '\t', '='
       */
-      if ((token = strtok (cbuf, separator)) == NULL)
+      if ((token = STRTOK (cbuf, separator, &saveptr)) == NULL)
         {
           continue;
         }
@@ -285,7 +286,7 @@ uReadSystemConfig (void)
       /*
       * put the rest of the string into var ent_val.
       */
-      if ((token = strtok (NULL, "\0")) == NULL)
+      if ((token = STRTOK (NULL, "\0", &saveptr)) == NULL)
         {
           continue;
         }

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -52,6 +52,8 @@
 #define DEFAULT_ASYNC_JOB_TTL_SEC  3600  /* how long a finished async job kept around for gettaskstatus polling */
 #define MIN_ASYNC_JOB_TTL_SEC      60    /* min async job TTL, 60 sec */
 
+#define DEFAULT_MAX_NUM_ASYNC_TASK 16    /* default max number of concurrently running async ("async":"yes") jobs */
+
 #define MAX_THREAD_NUM           64
 #define MIN_THREAD_NUM           1
 /* Reject multi connection with "ALL USER" */
@@ -240,6 +242,7 @@ uReadSystemConfig (void)
   sco.iSupportMonStat = FALSE;
   sco.iHttpTimeout = 30;
   sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
+  sco.iMaxNumAsyncTask = DEFAULT_MAX_NUM_ASYNC_TASK;
   sco.iAutoJobTimeout = DEFAULT_AUTOJOB_TIMEOUT;
   sco.iMaxLogFiles = DEFAULT_LOG_FILE_COUNT;
   sco.iMaxLogFileSize = DEFAULT_LOG_FILE_SIZE;
@@ -405,6 +408,21 @@ uReadSystemConfig (void)
             {
               sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
             }
+        }
+      else if (strcasecmp (ent_name, "max_num_async_task") == 0)
+        {
+          int max_task = atoi (ent_val);
+          if (max_task < 1 || max_task > CMS_MAX_NUM_ASYNC_TASK_LIMIT)
+            {
+              char err_buf[DBMT_ERROR_MSG_SIZE];
+
+              snprintf (err_buf, DBMT_ERROR_MSG_SIZE,
+                        "CUBRID Manager Server : max_num_async_task(%d) in cm.conf is invalid. it must be between 1 and %d.\n",
+                        max_task, CMS_MAX_NUM_ASYNC_TASK_LIMIT);
+              ut_record_cubrid_utility_log_stderr (err_buf);
+              exit (1);
+            }
+          sco.iMaxNumAsyncTask = max_task;
         }
       else if (strcasecmp (ent_name, "auto_update_url") == 0 ||
                strcasecmp (ent_name, "AutoUpdateURL") == 0)

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -49,6 +49,9 @@
 #define DEFAULT_AUTOJOB_TIMEOUT  43200    /* timeout for all autojobs, 12 hours */
 #define MIN_AUTOJOB_TIMEOUT      60    /* min timeout for all autojobs, 60 sec */
 
+#define DEFAULT_ASYNC_JOB_TTL_SEC  3600  /* how long a finished async job kept around for gettaskstatus polling */
+#define MIN_ASYNC_JOB_TTL_SEC      60    /* min async job TTL, 60 sec */
+
 #define MAX_THREAD_NUM           64
 #define MIN_THREAD_NUM           1
 /* Reject multi connection with "ALL USER" */
@@ -236,6 +239,7 @@ uReadSystemConfig (void)
   sco.iSupportWebManager = FALSE;
   sco.iSupportMonStat = FALSE;
   sco.iHttpTimeout = 30;
+  sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
   sco.iAutoJobTimeout = DEFAULT_AUTOJOB_TIMEOUT;
   sco.iMaxLogFiles = DEFAULT_LOG_FILE_COUNT;
   sco.iMaxLogFileSize = DEFAULT_LOG_FILE_SIZE;
@@ -389,6 +393,18 @@ uReadSystemConfig (void)
                strcasecmp (ent_name, "HttpTimeout") == 0)
         {
           sco.iHttpTimeout = atoi (ent_val);
+        }
+      else if (strcasecmp (ent_name, "async_job_ttl_sec") == 0)
+        {
+          int ttl = atoi (ent_val);
+          if (MIN_ASYNC_JOB_TTL_SEC <= ttl)
+            {
+              sco.iAsyncJobTtlSec = ttl;
+            }
+          else
+            {
+              sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
+            }
         }
       else if (strcasecmp (ent_name, "auto_update_url") == 0 ||
                strcasecmp (ent_name, "AutoUpdateURL") == 0)

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -54,6 +54,10 @@
 
 #define DEFAULT_MAX_NUM_ASYNC_TASK 16    /* default max number of concurrently running async ("async":"yes") jobs */
 
+#define DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC  86400  /* 24 hours */
+#define MIN_ASYNC_JOB_MAX_RUNNING_SEC      60     /* min, 60 sec */
+#define MAX_ASYNC_JOB_MAX_RUNNING_SEC      259200 /* 3 days */
+
 #define MAX_THREAD_NUM           64
 #define MIN_THREAD_NUM           1
 /* Reject multi connection with "ALL USER" */
@@ -243,6 +247,7 @@ uReadSystemConfig (void)
   sco.iHttpTimeout = 30;
   sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
   sco.iMaxNumAsyncTask = DEFAULT_MAX_NUM_ASYNC_TASK;
+  sco.iAsyncJobMaxRunningSec = DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC;
   sco.iAutoJobTimeout = DEFAULT_AUTOJOB_TIMEOUT;
   sco.iMaxLogFiles = DEFAULT_LOG_FILE_COUNT;
   sco.iMaxLogFileSize = DEFAULT_LOG_FILE_SIZE;
@@ -429,6 +434,19 @@ uReadSystemConfig (void)
               exit (1);
             }
           sco.iMaxNumAsyncTask = max_task;
+        }
+      else if (strcasecmp (ent_name, "async_job_max_running_sec") == 0)
+        {
+          int max_running = atoi (ent_val);
+
+          if (MIN_ASYNC_JOB_MAX_RUNNING_SEC <= max_running && max_running < MAX_ASYNC_JOB_MAX_RUNNING_SEC)
+            {
+              sco.iAsyncJobMaxRunningSec = max_running;
+            }
+          else
+            {
+              sco.iAsyncJobMaxRunningSec = DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC;
+            }
         }
       else if (strcasecmp (ent_name, "auto_update_url") == 0 ||
                strcasecmp (ent_name, "AutoUpdateURL") == 0)

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -399,6 +399,8 @@ uReadSystemConfig (void)
         }
       else if (strcasecmp (ent_name, "async_job_ttl_sec") == 0)
         {
+          char err_buf[DBMT_ERROR_MSG_SIZE];
+
           int ttl = atoi (ent_val);
           if (MIN_ASYNC_JOB_TTL_SEC <= ttl)
             {
@@ -407,6 +409,10 @@ uReadSystemConfig (void)
           else
             {
               sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
+              snprintf (err_buf, DBMT_ERROR_MSG_SIZE,
+                    "CUBRID Manager Server: invalid async_job_ttl_sec in cm.conf (%s). use default (%d secs)\n",
+                    ent_val, DEFAULT_ASYNC_JOB_TTL_SEC);
+                    ut_record_cubrid_utility_log_stderr (err_buf);
             }
         }
       else if (strcasecmp (ent_name, "max_num_async_task") == 0)

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -52,11 +52,11 @@
 #define DEFAULT_ASYNC_JOB_TTL_SEC  3600  /* how long a finished async job kept around for gettaskstatus polling */
 #define MIN_ASYNC_JOB_TTL_SEC      60    /* min async job TTL, 60 sec */
 
-#define DEFAULT_MAX_NUM_ASYNC_TASK 16    /* default max number of concurrently running async ("async":"yes") jobs */
+#define DEFAULT_MAX_NUM_ASYNC_TASK 8     /* default max number of concurrently running async ("async":"yes") jobs */
 
 #define DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC  86400  /* 24 hours */
 #define MIN_ASYNC_JOB_MAX_RUNNING_SEC      60     /* min, 60 sec */
-#define MAX_ASYNC_JOB_MAX_RUNNING_SEC      259200 /* 3 days */
+#define MAX_ASYNC_JOB_MAX_RUNNING_SEC      604800 /* 1 week */
 
 #define MAX_THREAD_NUM           64
 #define MIN_THREAD_NUM           1

--- a/server/src/cm_config.cpp
+++ b/server/src/cm_config.cpp
@@ -54,9 +54,9 @@
 
 #define DEFAULT_MAX_NUM_ASYNC_TASK 8     /* default max number of concurrently running async ("async":"yes") jobs */
 
-#define DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC  86400  /* 24 hours */
-#define MIN_ASYNC_JOB_MAX_RUNNING_SEC      60     /* min, 60 sec */
-#define MAX_ASYNC_JOB_MAX_RUNNING_SEC      604800 /* 1 week */
+#define DEFAULT_ASYNC_LONG_JOB_SEC  86400  /* 24 hours */
+#define MIN_ASYNC_LONG_JOB_SEC      60     /* min, 60 sec */
+#define MAX_ASYNC_LONG_JOB_SEC      604800 /* 1 week */
 
 #define MAX_THREAD_NUM           64
 #define MIN_THREAD_NUM           1
@@ -248,7 +248,7 @@ uReadSystemConfig (void)
   sco.iHttpTimeout = 30;
   sco.iAsyncJobTtlSec = DEFAULT_ASYNC_JOB_TTL_SEC;
   sco.iMaxNumAsyncTask = DEFAULT_MAX_NUM_ASYNC_TASK;
-  sco.iAsyncJobMaxRunningSec = DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC;
+  sco.iAsyncLongJobSec = DEFAULT_ASYNC_LONG_JOB_SEC;
   sco.iAutoJobTimeout = DEFAULT_AUTOJOB_TIMEOUT;
   sco.iMaxLogFiles = DEFAULT_LOG_FILE_COUNT;
   sco.iMaxLogFileSize = DEFAULT_LOG_FILE_SIZE;
@@ -436,17 +436,17 @@ uReadSystemConfig (void)
             }
           sco.iMaxNumAsyncTask = max_task;
         }
-      else if (strcasecmp (ent_name, "async_job_max_running_sec") == 0)
+      else if (strcasecmp (ent_name, "async_long_job_sec") == 0)
         {
-          int max_running = atoi (ent_val);
+          int long_job_sec = atoi (ent_val);
 
-          if (MIN_ASYNC_JOB_MAX_RUNNING_SEC <= max_running && max_running < MAX_ASYNC_JOB_MAX_RUNNING_SEC)
+          if (MIN_ASYNC_LONG_JOB_SEC <= long_job_sec && long_job_sec < MAX_ASYNC_LONG_JOB_SEC)
             {
-              sco.iAsyncJobMaxRunningSec = max_running;
+              sco.iAsyncLongJobSec = long_job_sec;
             }
           else
             {
-              sco.iAsyncJobMaxRunningSec = DEFAULT_ASYNC_JOB_MAX_RUNNING_SEC;
+              sco.iAsyncLongJobSec = DEFAULT_ASYNC_LONG_JOB_SEC;
             }
         }
       else if (strcasecmp (ent_name, "auto_update_url") == 0 ||

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -600,7 +600,7 @@ typedef struct
   int iHttpTimeout;
   int iAsyncJobTtlSec;
   int iMaxNumAsyncTask;
-  int iAsyncJobMaxRunningSec;
+  int iAsyncLongJobSec;
   char szAutoUpdateURL[PATH_MAX];
   char szCMSVersion[PATH_MAX];
   char szTokenActiveTime[PATH_MAX];

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -596,6 +596,7 @@ typedef struct
   int iSupportWebManager;
   int iSupportMonStat;
   int iHttpTimeout;
+  int iAsyncJobTtlSec;
   char szAutoUpdateURL[PATH_MAX];
   char szCMSVersion[PATH_MAX];
   char szTokenActiveTime[PATH_MAX];

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -32,7 +32,7 @@
 #define MAX_INSTALLED_DB                256
 #define MAX_UNICAS_PROC                 40
 
-#define CMS_MAX_NUM_ASYNC_TASK_LIMIT    64
+#define CMS_MAX_NUM_ASYNC_TASK_LIMIT    12
 
 #define MIN_ENCRYPT_LEN                 32
 #define ENCRYPT_SIGN                    "@"

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -600,6 +600,7 @@ typedef struct
   int iHttpTimeout;
   int iAsyncJobTtlSec;
   int iMaxNumAsyncTask;
+  int iAsyncJobMaxRunningSec;
   char szAutoUpdateURL[PATH_MAX];
   char szCMSVersion[PATH_MAX];
   char szTokenActiveTime[PATH_MAX];

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -32,6 +32,8 @@
 #define MAX_INSTALLED_DB                256
 #define MAX_UNICAS_PROC                 40
 
+#define CMS_MAX_NUM_ASYNC_TASK_LIMIT    64
+
 #define MIN_ENCRYPT_LEN                 32
 #define ENCRYPT_SIGN                    "@"
 #define ENCRYPT_ARG(arg)                (ENCRYPT_SIGN arg)
@@ -597,6 +599,7 @@ typedef struct
   int iSupportMonStat;
   int iHttpTimeout;
   int iAsyncJobTtlSec;
+  int iMaxNumAsyncTask;
   char szAutoUpdateURL[PATH_MAX];
   char szCMSVersion[PATH_MAX];
   char szTokenActiveTime[PATH_MAX];

--- a/server/src/cm_config.h
+++ b/server/src/cm_config.h
@@ -627,9 +627,12 @@ extern const char *autounicas_conf_entry[AUTOUNICAS_CONF_ENTRY_NUM];
 extern const char *autobackup_period_type[AUTOBACKUP_PERIOD_TYPE_NUM];
 extern const char *autobackup_period_week[AUTOBACKUP_PERIOD_WEEK_NUM];
 
+#define CUBRID_VERSION_BUILD_LEN	64
+
 extern int cubrid_version_major;
 extern int cubrid_version_minor;
-void find_and_parse_cub_admin_version (int &major_version, int &minor_version);
+extern char cubrid_version_build[CUBRID_VERSION_BUILD_LEN];
+void find_and_parse_cub_admin_version (int &major_version, int &minor_version, char *build_version, size_t build_version_size);
 #define IS_INVALID_CUBRID_VERS_MAJOR(major)	(major <= 0)
 #define CUBRID_VERS(major,minor)	(major*100 + minor)
 

--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -82,8 +82,6 @@ static THREAD_FUNC automation_start (void *ud);
 static THREAD_FUNC aj_thread_r (void *aj);
 static void start_auto_thread (void);
 
-T_EMGR_VERSION CLIENT_VERSION = EMGR_MAKE_VER (8, 4);
-
 #ifdef WINDOWS
 T_THREAD auto_task_tid = NULL;
 #else

--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -117,6 +117,7 @@ struct worker_context
 
 int cubrid_version_major = -1;
 int cubrid_version_minor = -1;
+char cubrid_version_build[CUBRID_VERSION_BUILD_LEN] = "";
 
 int
 bind_socket (int port)
@@ -935,8 +936,8 @@ main (int argc, char **argv)
 
   start_auto_thread ();
 
-  find_and_parse_cub_admin_version (cubrid_version_major, cubrid_version_minor);
-  LOG_INFO ("started '%s' with Engine Version: %d.%d", argv[0], cubrid_version_major, cubrid_version_minor);
+  find_and_parse_cub_admin_version (cubrid_version_major, cubrid_version_minor, cubrid_version_build, sizeof (cubrid_version_build));
+  LOG_INFO ("started '%s' with Engine Version: %d.%d (%s)", argv[0], cubrid_version_major, cubrid_version_minor, cubrid_version_build);
 
   start_service ();
 

--- a/server/src/cm_httpd.cpp
+++ b/server/src/cm_httpd.cpp
@@ -31,6 +31,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <string.h>
+#include <stdexcept>
 #include <event2/event.h>
 #include <evhttp.h>
 #include <event2/buffer.h>
@@ -271,14 +272,32 @@ cub_generic_request_handler (struct evhttp_request *req, void *arg)
 
   cub_add_private_param (req, root);
 
-  if (!strcmp ((char *) arg, "cci"))
+  try
     {
-      cub_cci_request_handler (root, response);
+      if (!strcmp ((char *) arg, "cci"))
+	{
+	  cub_cci_request_handler (root, response);
+	}
+      else if (!strcmp ((char *) arg, "cm_api"))
+	{
+	  cub_cm_request_handler (root, response);
+	}
     }
-  else if (!strcmp ((char *) arg, "cm_api"))
+  catch (const std::exception &e)
     {
-      cub_cm_request_handler (root, response);
+      LOG_ERROR ("cub_generic_request_handler : unhandled exception while "
+                "processing request: %s", e.what ());
+      response = Json::Value (Json::objectValue);
+      build_server_header (response, ERR_WITH_MSG, e.what ());
     }
+  catch (...)
+    {
+      LOG_ERROR ("cub_generic_request_handler : unhandled non-standard "
+                "exception while processing request.");
+      response = Json::Value (Json::objectValue);
+      build_server_header (response, ERR_WITH_MSG, "internal server error");
+    }
+
 
   //outustr = utf8_encode(writer.write(response).c_str());
   //printf("---------------------\n%s\n", outustr);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -139,7 +139,6 @@ using namespace std;
 
 #define        ER_FEATURE_DEPRECATED   -2
 
-extern T_EMGR_VERSION CLIENT_VERSION;
 extern T_USER_TOKEN_INFO *user_token_info;
 
 typedef struct

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -444,7 +444,7 @@ _run_child (const char *const argv[], int wait_flag, char *task_name,
   make_temp_filepath (tmp_err_file, sco.dbmt_tmp_dir, buf, TS_RUN_CHILD, PATH_MAX);
 
   if (run_child_env
-      (argv, wait_flag, NULL, tmp_out_file, tmp_err_file, envp, &exit_code) < 0)
+      (argv, wait_flag, NULL, tmp_out_file, tmp_err_file, &exit_code, envp) < 0)
     {
       snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "%s", argv[0]);
       ret_val = ERR_SYSTEM_CALL;
@@ -8672,7 +8672,7 @@ ts_trigger_operation (nvplist *req, nvplist *res, char *_dbmt_error)
   {
     const char *extra_envp[] = TRANSACTION_NO_WAIT_MODE_ENVP;
 
-    retval = run_child_env (argv, 1, NULL, NULL, cubrid_err_file, extra_envp, NULL);    /* csql - trigger */
+    retval = run_child_env (argv, 1, NULL, NULL, cubrid_err_file, NULL, extra_envp);    /* csql - trigger */
   }
   if (strlen (input_file) > 0)
     {
@@ -9975,9 +9975,9 @@ ts_executecasrunner (nvplist *cli_request, nvplist *cli_response,
 
 #if defined (WINDOWS)
     status = EXIT_SUCCESS;
-    ret = run_child_env (argv, 1, NULL, NULL, NULL, extra_envp, NULL);
+    ret = run_child_env (argv, 1, NULL, NULL, NULL, NULL, extra_envp);
 #else
-    ret = run_child_env (argv, 1, NULL, NULL, NULL, extra_envp, &status);
+    ret = run_child_env (argv, 1, NULL, NULL, NULL, &status, extra_envp);
 #endif
   }
 
@@ -11635,9 +11635,9 @@ ts_run_script (nvplist *req, nvplist *res, char *_dbmt_error)
 
   /* run *.bat or *.sh. */
 #if defined (WINDOWS)
-  ret = run_child_env (argv, 1, NULL, outfile, errfile, extra_envp, NULL);
+  ret = run_child_env (argv, 1, NULL, outfile, errfile, NULL, extra_envp);
 #else
-  ret = run_child_env (argv, 1, NULL, outfile, errfile, extra_envp, &status);
+  ret = run_child_env (argv, 1, NULL, outfile, errfile, &status, extra_envp);
 #endif
   if (ret < 0 || status != EXIT_SUCCESS)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -6165,6 +6165,7 @@ _check_backup_info (const char *conf_item[], int check_backupid,
   char conf_value_item[NAME_MAX];
 
   char *token = NULL;
+  char *saveptr;
 
   int i = 0;
   int period_type_exist = 0;
@@ -6236,7 +6237,7 @@ _check_backup_info (const char *conf_item[], int check_backupid,
   if ((strcmp (conf_item[3], AUTO_BACKUP_PERIOD_TYPE_MONTHLY) == 0))
     {
       snprintf (conf_value_item, NAME_MAX, "%s", conf_item[4]);
-      token = strtok (conf_value_item, " ,");
+      token = STRTOK (conf_value_item, " ,", &saveptr);
       while (token != NULL)
 	{
 	  period_date = atoi (token);
@@ -6248,14 +6249,14 @@ _check_backup_info (const char *conf_item[], int check_backupid,
 	      return ERR_WITH_MSG;
 	    }
 
-	  token = strtok (NULL, " ,");
+	  token = STRTOK (NULL, " ,", &saveptr);
 	}
     }
   /* period_date: Weekly */
   else if (strcmp (conf_item[3], AUTO_BACKUP_PERIOD_TYPE_WEEKLY) == 0)
     {
       snprintf (conf_value_item, NAME_MAX, "%s", conf_item[4]);
-      token = strtok (conf_value_item, " ,");
+      token = STRTOK (conf_value_item, " ,", &saveptr);
       while (token != NULL)
 	{
 	  for (i = 0; i < AUTOBACKUP_PERIOD_WEEK_NUM; i++)
@@ -6276,7 +6277,7 @@ _check_backup_info (const char *conf_item[], int check_backupid,
 	    }
 
 	  period_date_exist = 0;
-	  token = strtok (NULL, " ,");
+	  token = STRTOK (NULL, " ,", &saveptr);
 	}
     }
   /* period_date: Daily */
@@ -6300,7 +6301,7 @@ _check_backup_info (const char *conf_item[], int check_backupid,
   else
     {
       snprintf (conf_value_item, NAME_MAX, "%s", conf_item[4]);
-      token = strtok (conf_value_item, " ,");
+      token = STRTOK (conf_value_item, " ,", &saveptr);
       while (token != NULL)
 	{
 	  /* convert period_date from YYYY-MM-DD into YYYYMMDD */
@@ -6321,7 +6322,7 @@ _check_backup_info (const char *conf_item[], int check_backupid,
 			conf_item[4], autobackup_conf_entry[4]);
 	      return ERR_WITH_MSG;
 	    }
-	  token = strtok (NULL, " ,");
+	  token = STRTOK (NULL, " ,", &saveptr);
 	}
     }
   /* check time */

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -11574,7 +11574,12 @@ ts_run_script (nvplist *req, nvplist *res, char *_dbmt_error)
   make_temp_filepath (outfile, sco.dbmt_tmp_dir, "DBMT_task_out", TS_RUN_SCRIPT, PATH_MAX);
   make_temp_filepath (errfile, sco.dbmt_tmp_dir, "DBMT_task_err", TS_RUN_SCRIPT, PATH_MAX);
 
+  /*
+   * putenv () in runscript api will not be allowed for a while
+   * for thread-safety
+   */
   /* set environment that the script need to run. */
+#if 0
   for (i = 0; i < req->nvplist_leng; i++)
     {
       nv_lookup (req, i, &n, &v);
@@ -11583,6 +11588,7 @@ ts_run_script (nvplist *req, nvplist *res, char *_dbmt_error)
 	  putenv (v);
 	}
     }
+#endif
 
   if ((script_path = nv_get_val (req, "script_path")) == NULL)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5563,7 +5563,12 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (exit_status != 0)
     {
-      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "loaddb failed with exit status: %d", exit_status);
+#if defined (WINDOWS)
+  int exit_code = exit_status;
+#else
+  int exit_code = WIFEXITED (exit_status) ? WEXITSTATUS (exit_status) : exit_status;
+#endif
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "loaddb failed with exit status: %d", exit_code);
       return ERR_WITH_MSG;
     }
 

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -9956,16 +9956,21 @@ ts_executecasrunner (nvplist *cli_request, nvplist *cli_response,
   argv[++i] = log_converter_res;
   argv[++i] = NULL;
 
-  snprintf (out_msg_file_env, sizeof (out_msg_file_env) - 1,
-	    "CUBRID_MANAGER_OUT_MSG_FILE=%s", resfile2);
-  putenv (out_msg_file_env);
+  {
+    const char *extra_envp[2];
+
+    snprintf (out_msg_file_env, sizeof (out_msg_file_env) - 1,
+	      "CUBRID_MANAGER_OUT_MSG_FILE=%s", resfile2);
+    extra_envp[0] = out_msg_file_env;
+    extra_envp[1] = NULL;
 
 #if defined (WINDOWS)
-  status = EXIT_SUCCESS;
-  ret = run_child (argv, 1, NULL, NULL, NULL, NULL);
+    status = EXIT_SUCCESS;
+    ret = run_child_env (argv, 1, NULL, NULL, NULL, extra_envp, NULL);
 #else
-  ret = run_child (argv, 1, NULL, NULL, NULL, &status);
+    ret = run_child_env (argv, 1, NULL, NULL, NULL, extra_envp, &status);
 #endif
+  }
 
   if (ret < 0 || status != EXIT_SUCCESS)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -2828,7 +2828,7 @@ tsCreateDB (nvplist *req, nvplist *res, char *_dbmt_error)
 
   make_temp_filepath (createdb_err_file, sco.dbmt_tmp_dir, "createdb_err_file", TS_CREATEDB, PATH_MAX);
 
-  retval = run_child (argv, 1, NULL, NULL, createdb_err_file, NULL);    /* createdb */
+  retval = run_child_env (argv, 1, NULL, NULL, createdb_err_file, NULL);    /* createdb */
 
   if (read_error_file (createdb_err_file, _dbmt_error, DBMT_ERROR_MSG_SIZE) < 0)
     {

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -1175,7 +1175,6 @@ ts2_get_logfile_info (nvplist *in, nvplist *out, char *_dbmt_error)
       strcpy (_dbmt_error, "broker");
       return ERR_PARAM_MISSING;
     }
-  chdir (sco.szCubrid);
   if (cm_get_broker_conf (&uc_conf, NULL, &error) < 0)
     {
       strcpy (_dbmt_error, error.err_msg);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -11575,25 +11575,8 @@ ts_run_script (nvplist *req, nvplist *res, char *_dbmt_error)
   int i;
   int status = EXIT_SUCCESS;
   int ret;
-
-  make_temp_filepath (outfile, sco.dbmt_tmp_dir, "DBMT_task_out", TS_RUN_SCRIPT, PATH_MAX);
-  make_temp_filepath (errfile, sco.dbmt_tmp_dir, "DBMT_task_err", TS_RUN_SCRIPT, PATH_MAX);
-
-  /*
-   * putenv () in runscript api will not be allowed for a while
-   * for thread-safety
-   */
-  /* set environment that the script need to run. */
-#if 0
-  for (i = 0; i < req->nvplist_leng; i++)
-    {
-      nv_lookup (req, i, &n, &v);
-      if ((n != NULL) && (strcmp (n, "envvar") == 0))
-	{
-	  putenv (v);
-	}
-    }
-#endif
+  int envc = 0;
+  const char **extra_envp = NULL;
 
   if ((script_path = nv_get_val (req, "script_path")) == NULL)
     {
@@ -11601,19 +11584,59 @@ ts_run_script (nvplist *req, nvplist *res, char *_dbmt_error)
       return ERR_PARAM_MISSING;
     }
 
+  make_temp_filepath (outfile, sco.dbmt_tmp_dir, "DBMT_task_out", TS_RUN_SCRIPT, PATH_MAX);
+  make_temp_filepath (errfile, sco.dbmt_tmp_dir, "DBMT_task_err", TS_RUN_SCRIPT, PATH_MAX);
+
+  /* set environment that the script need to run. */
+
+  for (i = 0; i < req->nvplist_leng; i++)
+    {
+      nv_lookup (req, i, &n, &v);
+      if ((n != NULL) && (v != NULL) && (strcmp (n, "envvar") == 0))
+	{
+	  envc++;
+	}
+    }
+
+  if (envc > 0)
+    {
+      extra_envp = (const char **) malloc (sizeof (const char *) * (envc + 1));
+      if (extra_envp == NULL)
+	{
+	  strcpy_limit (_dbmt_error, "malloc", DBMT_ERROR_MSG_SIZE);
+	  return ERR_SYSTEM_CALL;
+	}
+
+      envc = 0;
+      for (i = 0; i < req->nvplist_leng; i++)
+	{
+	  nv_lookup (req, i, &n, &v);
+	  if ((n != NULL) && (v != NULL) && (strcmp (n, "envvar") == 0))
+	    {
+	      extra_envp[envc++] = v;
+	    }
+	}
+      extra_envp[envc] = NULL;
+    }
+
   argv[argc++] = script_path;
   argv[argc++] = NULL;
 
   /* run *.bat or *.sh. */
 #if defined (WINDOWS)
-  ret = run_child (argv, 1, NULL, outfile, errfile, NULL);
+  ret = run_child_env (argv, 1, NULL, outfile, errfile, extra_envp, NULL);
 #else
-  ret = run_child (argv, 1, NULL, outfile, errfile, &status);
+  ret = run_child_env (argv, 1, NULL, outfile, errfile, extra_envp, &status);
 #endif
   if (ret < 0 || status != EXIT_SUCCESS)
     {
       strcpy_limit (_dbmt_error, argv[0], DBMT_ERROR_MSG_SIZE);
       retval = ERR_SYSTEM_CALL;
+    }
+
+  if (extra_envp != NULL)
+    {
+      free (extra_envp);
     }
 
   unlink (outfile);

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -5563,7 +5563,7 @@ ts_loaddb (nvplist *req, nvplist *res, char *_dbmt_error)
 
   if (exit_status != 0)
     {
-      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "loaddb failed with exit status: %d", WEXITSTATUS (exit_status));
+      snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "loaddb failed with exit status: %d", exit_status);
       return ERR_WITH_MSG;
     }
 

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -335,7 +335,8 @@ static char *_get_format_time ();
 static void read_stdout_stderr_as_err (char *tmp_out_file, char *tmp_err_file,
 				       char *_dbmt_error);
 static int _run_child (const char *const argv[], int wait_flag,
-		       char *task_name, char *stdout_file, char *_dbmt_error);
+		       char *task_name, char *stdout_file, char *_dbmt_error,
+		       const char *envp[] = NULL);
 static int _check_backup_info (const char *conf_item[], int check_backupid,
 			       char *_dbmt_error);
 static int _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
@@ -410,9 +411,15 @@ _verify_user_passwd (char *dbname, char *dbuser, char *dbpasswd,
   return retval;
 }
 
+/*
+ * _run_child () - run a child process (via run_child_env ()), read its
+ * error file into _dbmt_error on failure.
+ *
+ * envp (in) : extra "KEY=VALUE" entries that apply only to this child
+ */
 static int
 _run_child (const char *const argv[], int wait_flag, char *task_name,
-	    char *stdout_file, char *_dbmt_error)
+	    char *stdout_file, char *_dbmt_error, const char *envp[])
 {
   char tmp_out_file[PATH_MAX];
   char tmp_err_file[PATH_MAX];
@@ -436,8 +443,8 @@ _run_child (const char *const argv[], int wait_flag, char *task_name,
   snprintf (buf, PATH_MAX - 1, "%s_err_tmp", task_name);
   make_temp_filepath (tmp_err_file, sco.dbmt_tmp_dir, buf, TS_RUN_CHILD, PATH_MAX);
 
-  if (run_child
-      (argv, wait_flag, NULL, tmp_out_file, tmp_err_file, &exit_code) < 0)
+  if (run_child_env
+      (argv, wait_flag, NULL, tmp_out_file, tmp_err_file, envp, &exit_code) < 0)
     {
       snprintf (_dbmt_error, DBMT_ERROR_MSG_SIZE, "%s", argv[0]);
       ret_val = ERR_SYSTEM_CALL;
@@ -8661,9 +8668,12 @@ ts_trigger_operation (nvplist *req, nvplist *res, char *_dbmt_error)
     }
 
   make_temp_filepath (cubrid_err_file, sco.dbmt_tmp_dir, "trigger_operation_err_tmp", TS_GETTRIGGERINFO, PATH_MAX);
-  SET_TRANSACTION_NO_WAIT_MODE_ENV ();
 
-  retval = run_child (argv, 1, NULL, NULL, cubrid_err_file, NULL);    /* csql - trigger */
+  {
+    const char *extra_envp[] = TRANSACTION_NO_WAIT_MODE_ENVP;
+
+    retval = run_child_env (argv, 1, NULL, NULL, cubrid_err_file, extra_envp, NULL);    /* csql - trigger */
+  }
   if (strlen (input_file) > 0)
     {
       unlink (input_file);
@@ -10766,10 +10776,12 @@ run_csql_statement (const char *sql_stat, char *dbname, char *dbuser,
 
   argv[argc++] = NULL;
 
-  SET_TRANSACTION_NO_WAIT_MODE_ENV ();
-
   strncpy (task_name, "csql", TASKNAME_LEN);
-  retval = _run_child (argv, 1, task_name, outfilepath, _dbmt_error);
+  {
+    const char *extra_envp[] = TRANSACTION_NO_WAIT_MODE_ENVP;
+
+    retval = _run_child (argv, 1, task_name, outfilepath, _dbmt_error, extra_envp);
+  }
 
   return retval;
 }

--- a/server/src/cm_job_task.cpp
+++ b/server/src/cm_job_task.cpp
@@ -10272,7 +10272,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   char *targetid, *dbname, *dbuser, *dbpasswd;
   int isdba = 0;
   char outfile[PATH_MAX];
-  static int cmdid = 0;
+  static atomic_counter_t cmdid = 0;
   const char *statement = CUBRID_VERS (cubrid_version_major,cubrid_version_minor) < 1105 ?
 	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g.name}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;" :
 	"SELECT COUNT( * ) FROM db_user d WHERE {'DBA'} SUBSETEQ (SELECT SET{CURRENT_USER}+COALESCE(SUM(SET{t.g}), SET{}) from db_user u, TABLE(groups) AS t( g ) WHERE u.name = d.name) AND d.name=CURRENT_USER;";
@@ -10298,7 +10298,7 @@ cmd_dbmt_user_login (nvplist *in, nvplist *out, char *_dbmt_error)
   nv_add_nvp (out, "dbname", dbname);
 
   snprintf (outfile, sizeof (outfile) - 1, "%s/tmp/DBMT_user_login.%d",
-	    sco.szCubrid, cmdid++);
+	    sco.szCubrid, ATOMIC_FETCH_ADD1 (cmdid));
   errcode =
 	  run_csql_statement (statement, dbname, dbuser, dbpasswd, outfile, _dbmt_error);
   if (errcode != ERR_NO_ERROR)
@@ -14298,10 +14298,9 @@ ts_get_shard_info (nvplist *req, nvplist *res, char *_dbmt_error)
   int ret_val;
   char cmd_name[CUBRID_CMD_NAME_LEN];
   const char *argv[6];
-  static int reqid = 0;
+  static atomic_counter_t reqid = 0;
 
-  /* not thread safe :( */
-  reqid++;
+  ATOMIC_FETCH_ADD1 (reqid);
   sprintf (stdout_log_file, "%s/cmshardinfo.%d.err", sco.dbmt_tmp_dir, reqid);
   sprintf (stderr_log_file, "%s/cmshardinfo2.%d.err", sco.dbmt_tmp_dir, reqid);
 
@@ -14446,15 +14445,15 @@ ts_get_shard_status (nvplist *req, nvplist *res, char *_dbmt_error)
   char cmd_name[CUBRID_CMD_NAME_LEN];
   const char *argv[6];
   char *sname;
-  static int reqid = 0;
+  static atomic_counter_t reqid = 0;
 
   if ((sname = nv_get_val (req, "shardname")) == NULL)
     {
       strcpy (_dbmt_error, "shard name");
       return ERR_PARAM_MISSING;
     }
-  /* not thread safe :( */
-  reqid++;
+
+  ATOMIC_FETCH_ADD1 (reqid);
   sprintf (stdout_log_file, "%s/cmshardstatus.%d.err", sco.dbmt_tmp_dir, reqid);
   sprintf (stderr_log_file, "%s/cmshardstatus2.%d.err", sco.dbmt_tmp_dir, reqid);
 

--- a/server/src/cm_job_task.h
+++ b/server/src/cm_job_task.h
@@ -41,11 +41,8 @@
 #define SIZE_BUFFER_MAX        1024
 #endif
 
-#define SET_TRANSACTION_NO_WAIT_MODE_ENV()                                              \
-      do {                                                                              \
-      putenv((char *) "CUBRID_LOCK_TIMEOUT_IN_SECS=1");                                 \
-      putenv((char *) "CUBRID_ISOLATION_LEVEL=TRAN_READ_COMMITTED");                    \
-    } while (0)
+#define TRANSACTION_NO_WAIT_MODE_ENVP                                                   \
+      { "CUBRID_LOCK_TIMEOUT_IN_SECS=1", "CUBRID_ISOLATION_LEVEL=TRAN_READ_COMMITTED", NULL }
 
 typedef enum
 {

--- a/server/src/cm_porting.h
+++ b/server/src/cm_porting.h
@@ -336,4 +336,11 @@ typedef long INT64;
 #define COND_DESTROY(condvar)        pthread_cond_destroy(&(condvar))
 #endif
 
+#if defined(WINDOWS)
+typedef volatile LONG atomic_counter_t;
+#define ATOMIC_FETCH_ADD1(cnt)  InterlockedExchangeAdd(&(cnt), 1)
+#else
+typedef volatile int atomic_counter_t;
+#define ATOMIC_FETCH_ADD1(cnt)  __sync_fetch_and_add(&(cnt), 1)
+#endif
 #endif /* _CM_PORTING_H_ */

--- a/server/src/cm_server_autoupdate.cpp
+++ b/server/src/cm_server_autoupdate.cpp
@@ -350,19 +350,13 @@ unzip (const char *zip_file, const char *unzip_dir)
           if (access (unzip_file, 0) != 0
               && !CreateDirectory (unzip_file, NULL))
 #else
-          mode_t old_mode = umask (0);
-          if (access (unzip_file, 0) != 0 && mkdir (unzip_file, 0700) != 0)
+          if (access (unzip_file, 0) != 0
+              && (mkdir (unzip_file, 0700) != 0 || chmod (unzip_file, 0700) != 0))
 #endif
             {
-#ifndef WINDOWS
-              umask (old_mode);
-#endif
               mz_zip_reader_end (&zip_archive);
               return MZ_FALSE;
             }
-#ifndef WINDOWS
-          umask (old_mode);
-#endif
           continue;
         }
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1276,7 +1276,7 @@ cub_check_server_status (Json::Value &request, Json::Value &response)
   req_list_status["running"] = running;
   req_list_status["finished_pending_ttl"] = finished_pending_ttl;
   req_list_status["long_jobs"] = long_jobs;
-  req_list_status["oldest_running_sec"] = oldest_running_sec;
+  req_list_status["longest_task_running_sec"] = oldest_running_sec;
   req_list_status["long_job_list"] = long_job_list;
   response["request-list"] = req_list_status;
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1195,6 +1195,110 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
   return ERR_NO_ERROR;
 }
 
+/*
+ * cub_check_server_status () - handle a "getserverstatus" query: an
+ *   admin-only, instant (no worker thread, no external process) health
+ *   snapshot of the async-job subsystem, 'admin' user only
+ */
+int
+cub_check_server_status (Json::Value &request, Json::Value &response)
+{
+  string task = request["task"].asString ();
+  char vers[32];
+
+  if (task != "getserverstatus")
+    {
+      return 0;
+    }
+
+  if (request.get ("_ID", "").asString () != "admin")
+    {
+      response["status"] = STATUS_FAILURE;
+      response["note"] = "The user don't have authority to execute the task: getserverstatus";
+      response["task"] = task;
+      return 1;
+    }
+
+  reap_stale_async_jobs ();
+
+  time_t now = time (NULL);
+
+  Json::Value conf;
+  snprintf (vers, sizeof (vers), "%d.%d", cubrid_version_major,cubrid_version_minor);
+  conf["CUBRID Version"] = vers;
+  conf["async_job_ttl_sec"] = sco.iAsyncJobTtlSec;
+  conf["async_long_job_sec"] = sco.iAsyncLongJobSec;
+  conf["max_num_async_task"] = sco.iMaxNumAsyncTask;
+  conf["http_timeout"] = sco.iHttpTimeout;
+  response["cm-conf"] = conf;
+
+  int total = 0, running = 0, finished_pending_ttl = 0, long_jobs = 0;
+  int oldest_running_sec = 0;
+  Json::Value long_job_list;
+
+  for (map < INT64, async_request * >::iterator itor = request_list.begin ();
+       itor != request_list.end (); ++itor)
+    {
+      async_request *cur = itor->second;
+
+      total++;
+
+      if (cur->status != 0)
+        {
+          finished_pending_ttl++;
+          continue;
+        }
+
+      running++;
+
+      int elapsed_sec = (int) (now - cur->created_at);
+      if (elapsed_sec > oldest_running_sec)
+        {
+          oldest_running_sec = elapsed_sec;
+        }
+
+      if (cur->is_long_async_job)
+        {
+          long_jobs++;
+
+          Json::Value j;
+          put_uuid (j, cur->uuid);
+          j["task"] = cur->request.get ("task", "unknown").asString ();
+          j["db_name"] = cur->db_name;
+          j["requester_id"] = cur->requester_id;
+          j["elapsed_sec"] = elapsed_sec;
+          long_job_list.append (j);
+        }
+    }
+
+  Json::Value req_list_status;
+  req_list_status["total"] = total;
+  req_list_status["running"] = running;
+  req_list_status["finished_pending_ttl"] = finished_pending_ttl;
+  req_list_status["long_jobs"] = long_jobs;
+  req_list_status["oldest_running_sec"] = oldest_running_sec;
+  req_list_status["long_job_list"] = long_job_list;
+  response["request-list"] = req_list_status;
+
+  Json::Value slot;
+  slot["in_use"] = num_running_async_tasks;
+  slot["max"] = sco.iMaxNumAsyncTask;
+  response["async-slot"] = slot;
+
+  Json::Value db_busy;
+  for (map <string, string>::iterator itor = db_running_async.begin ();
+       itor != db_running_async.end (); ++itor)
+    {
+      Json::Value d;
+      d["task"] = itor->second;
+      d["db_name"] = itor->first;
+      db_busy.append (d);
+    }
+  response["db-running-async"] = db_busy;
+
+  return build_server_header (response, ERR_NO_ERROR, "none");
+}
+
 int
 cub_cm_request_handler (Json::Value &request, Json::Value &response)
 {
@@ -1220,6 +1324,11 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
     }
 
   if (cub_check_async_status (request, response))
+    {
+      mutex_unlock (cm_mutex);
+      return 1;
+    }
+  if (cub_check_server_status (request, response))
     {
       mutex_unlock (cm_mutex);
       return 1;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -857,7 +857,11 @@ parse_uuid (const Json::Value &v, INT64 &out)
       /* strtoull (not strtoul): on Windows "unsigned long" is only 32
        * bits, which would silently truncate a uuid here even though
        * req_id/out are a full 64-bit INT64. */
+#if defined (WINDOWS)
+      unsigned long long parsed = _strtoui64 (s.c_str (), &endptr, 10);
+#else
       unsigned long long parsed = strtoull (s.c_str (), &endptr, 10);
+#endif
       if (endptr == s.c_str () || *endptr != '\0')
         {
 	  return false;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -848,7 +848,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   dwWaitResult = WaitForSingleObject (hHandles, time_out * 1000);    //  time-out interval
 
-  if (dwWaitResult == WAIT_TIMEOUT)
+  if (dwWaitResult != WAIT_OBJECT_0)
     {
       CloseHandle (hHandles);
       mutex_lock (cm_mutex);

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -586,8 +586,11 @@ cm_async_request_handler (void *lpArg)
       response["note"] = e.what ();
     }
 
+  mutex_lock (cm_mutex);
   async_param->finished_at = time (NULL);
   async_param->status = 1;
+  mutex_unlock (cm_mutex);
+
   nv_destroy (cli_request);
   nv_destroy (cli_response);
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -614,7 +614,7 @@ class async_request
     std::string db_name;
     std::string requester_id;
     bool holds_async_slot;
-    bool max_running_warned;
+    bool is_long_async_job;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
@@ -654,20 +654,20 @@ reap_stale_async_jobs (void)
           continue;
         }
 
-      if (cur->status == 0 && !cur->max_running_warned
-          && (now - cur->created_at) > sco.iAsyncJobMaxRunningSec)
+      if (cur->status == 0 && !cur->is_long_async_job
+          && (now - cur->created_at) > sco.iAsyncLongJobSec)
         {
           string task_name = cur->request.get ("task", "unknown").asString ();
 
           LOG_ERROR ("reap_stale_async_jobs : job %lld (task '%s', db '%s') has been "
-                     "running for %d sec, past async_job_max_running_sec (%d sec); "
+                     "running for %d sec, past async_long_job_sec (%d sec); "
                      "its worker thread cannot be safely cancelled, so it is being "
                      "left in request_list until it actually finishes.",
                      (long long) cur->uuid, task_name.c_str (), cur->db_name.c_str (),
-                     (int) (now - cur->created_at), sco.iAsyncJobMaxRunningSec);
+                     (int) (now - cur->created_at), sco.iAsyncLongJobSec);
 
           /* log this only once per job, not on every reap_stale_async_jobs () call */
-          cur->max_running_warned = true;
+          cur->is_long_async_job = true;
         }
 
       ++itor;
@@ -814,7 +814,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
-  pstmt->max_running_warned = false;
+  pstmt->is_long_async_job = false;
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
@@ -1001,7 +1001,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
-  pstmt->max_running_warned = false;
+  pstmt->is_long_async_job = false;
 
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -846,15 +846,6 @@ parse_uuid (const Json::Value &v, INT64 &out)
  * cub_check_async_status () - handle a "gettaskstatus"
  *   poll for a job previously started with "async":"yes" (or one that
  *   fell back to async because it ran past sco.iHttpTimeout).
- *
- *   accepts the "uuid" while the job is still running this reports
- *   job-status:"running" via a normal
- *   ERR_NO_ERROR response instead of the previous ERR_WITH_MSG
- *   "task not return", since "still running" is an expected poll
- *   outcome, not a failure.
- *
- *   caller (cub_cm_request_handler) is expected to already hold
- *   cm_mutex when calling this, same as before.
  */
 int
 cub_check_async_status (Json::Value &request, Json::Value &response)

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <signal.h>
-#include <list>
+#include <map>
 
 #ifdef WINDOWS
 #include <process.h>
@@ -516,7 +516,7 @@ class async_request
 #endif
 };
 
-list < async_request * >request_list;
+map < INT64, async_request * > request_list;
 
 /*
  * reap_stale_async_jobs () - drop finished jobs that have been sitting in
@@ -531,21 +531,21 @@ static void
 reap_stale_async_jobs (void)
 {
   time_t now = time (NULL);
-  list < async_request * >::iterator itor = request_list.begin ();
+  map < INT64, async_request * > ::iterator itor = request_list.begin ();
 
   while (itor != request_list.end ())
     {
-      if ((*itor)->status != 0 && (now - (*itor)->finished_at) > sco.iAsyncJobTtlSec)
+      async_request *cur = itor->second;
+      if (cur->status != 0 && (now - cur->finished_at) > sco.iAsyncJobTtlSec)
         {
-          async_request *stale = *itor;
           itor = request_list.erase (itor);
 #ifndef WINDOWS
-          pthread_mutex_destroy (stale->mutex);
-          pthread_cond_destroy (stale->cond);
-          delete stale->mutex;
-          delete stale->cond;
+          pthread_mutex_destroy (cur->mutex);
+          pthread_cond_destroy (cur->cond);
+          delete cur->mutex;
+          delete cur->cond;
 #endif
-          delete stale;
+          delete cur;
         }
       else
         {
@@ -553,6 +553,7 @@ reap_stale_async_jobs (void)
         }
     }
 }
+
 
 #ifdef WINDOWS
 DWORD WINAPI
@@ -657,7 +658,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       CloseHandle (hHandles);
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list.push_back (pstmt);
+      request_list[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
 
       put_uuid (response, pstmt->uuid);
@@ -672,7 +673,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       CloseHandle (hHandles);
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list.push_back (pstmt);
+      request_list[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
       put_uuid (response, pstmt->uuid);
       response["job-status"] = "running";
@@ -765,7 +766,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
        * and let the worker thread keep running in the background. */
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list.push_back (pstmt);
+      request_list[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
 
       put_uuid (response, pstmt->uuid);
@@ -790,11 +791,10 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       dbname = request.get ("dbname", "").asString();
       /* register the still-running job so gettaskstatus can
        * find it later. the original code returned here without ever
-       * push_back ()-ing pstmt, which meant a poll for this uuid always
-       * came back "uuid not found" and pstmt (plus its thread) leaked. */
+       */
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list.push_back (pstmt);
+      request_list[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
       put_uuid (response, pstmt->uuid);
       response["job-status"] = "running";
@@ -867,7 +867,7 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
 {
   string task;
   INT64 uuid;
-  list < async_request * >::iterator itor;
+  map < INT64, async_request * > ::iterator itor;
   task = request["task"].asString ();
 
   if (task != "gettaskstatus")
@@ -882,22 +882,15 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
       return build_server_header (response, ERR_WITH_MSG, "invalid uuid");
     }
 
-  for (itor = request_list.begin (); itor != request_list.end (); itor++)
-    {
-      if ((*itor)->uuid != uuid)
-        {
-          continue;
-        }
-      break;
-    }
+  itor = request_list.find (uuid);
   if (itor == request_list.end ())
     {
       return build_server_header (response, ERR_WITH_MSG, "uuid not found");
     }
 
-  if ((*itor)->status == 0)
+  if (itor->second->status == 0)
     {
-      put_uuid (response, (*itor)->uuid);
+      put_uuid (response, itor->second->uuid);
       response["job-status"] = "running";
       return build_server_header (response, ERR_NO_ERROR, "none");
     }
@@ -910,13 +903,12 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
    * each time. the job is only ever reclaimed by reap_stale_async_jobs
    * (), once sco.iAsyncJobTtlSec seconds have passed since it was
    * created (see cm.conf's "async_job_ttl_sec"). */
-  response = (*itor)->response;
-  put_uuid (response, (*itor)->uuid);
+  response = itor->second->response;
+  put_uuid (response, itor->second->uuid);
   response["job-status"] = (response["status"].isString () &&
 			    response["status"].asString () == STATUS_SUCCESS) ? "success" : "error";
   return ERR_NO_ERROR;
 }
-
 
 int
 cub_cm_request_handler (Json::Value &request, Json::Value &response)

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -26,7 +26,6 @@
 #include <assert.h>
 #include <signal.h>
 #include <map>
-#include <atomic>
 
 #ifdef WINDOWS
 #include <process.h>
@@ -173,8 +172,8 @@ cub_cm_destory_env ()
 int
 ch_build_request (Json::Value &req, nvplist *cli_request)
 {
-  static std::atomic <unsigned int> i (0);
-  nv_add_nvp_int (cli_request, "_STAMP", i++);
+  static atomic_counter_t i = 0;
+  nv_add_nvp_int (cli_request, "_STAMP", (int) ATOMIC_FETCH_ADD1 (i));
   nv_add_nvp (cli_request, "_PROGNAME", CMS_NAME);
 
   return 1;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -585,16 +585,17 @@ cm_async_request_handler (void *lpArg)
       response["note"] = e.what ();
     }
 
-  mutex_lock (cm_mutex);
-  async_param->finished_at = time (NULL);
-  async_param->status = 1;
-  mutex_unlock (cm_mutex);
-
   nv_destroy (cli_request);
   nv_destroy (cli_response);
 
 #ifndef WINDOWS
   pthread_mutex_lock (async_param->mutex);
+#endif
+  mutex_lock (cm_mutex);
+  async_param->finished_at = time (NULL);
+  async_param->status = 1;
+  mutex_unlock (cm_mutex);
+#ifndef WINDOWS
   pthread_cond_broadcast (async_param->cond);
   pthread_mutex_unlock (async_param->mutex);
 #endif

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -133,7 +133,6 @@ cub_cm_init_env ()
   memset (&cub_httpd_env, 0, sizeof (cubrid_env_t));
   putenv (default_cubrid_lang_type);    /* set as default language type */
   putenv (default_cubrid_lang_msg_type);    /* set as default language type */
-  //putenv ("CUBRID_CHARSET=en_US");    /* set as default language type */
 
   snprintf (cub_httpd_env.cubrid_err_log, MAX_PATH,
             "CUBRID_ERROR_LOG=%s/cmclt.%d.err", sco.dbmt_tmp_dir, (int) getpid ());
@@ -146,19 +145,6 @@ cub_cm_init_env ()
             sco.szCubrid_databases);
   putenv (cub_httpd_env.cubrid_databases);
 
-  /*  charset = getenv ("CUBRID_CHARSET");
-  if (charset != NULL)
-  {
-      snprintf (cub_httpd_env.cubrid_charset, MAX_PATH, "CUBRID_CHARSET=%s",
-                charset);
-  }
-  else
-  {
-      snprintf (cub_httpd_env.cubrid_charset, MAX_PATH,
-                "CUBRID_CHARSET=en_US");
-      putenv (cub_httpd_env.cubrid_charset);
-  }
-  */
   mutex_init (cm_mutex);
   return;
 }
@@ -277,12 +263,6 @@ ch_process_request (nvplist *req, nvplist *res)
           ut_access_log (req, NULL);
         }
 
-      /*    if (charset != NULL)
-      {
-      snprintf (charsetenv, PATH_MAX, "CUBRID_CHARSET=%s", charset);
-      putenv (charsetenv);
-      }
-      */
       /* record the start time of running cub_manager */
       gettimeofday (&task_begin, NULL);
 
@@ -290,11 +270,7 @@ ch_process_request (nvplist *req, nvplist *res)
 
       /* record the end time of running cub_manager */
       gettimeofday (&task_end, NULL);
-      /*     if (charset != NULL)
-      {
-      putenv (cub_httpd_env.cubrid_charset);
-      }
-      */
+
       /* caculate the running time of cub_manager. */
       _ut_timeval_diff (&task_begin, &task_end, &elapsed_msec);
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -60,6 +60,8 @@ mutex_t cm_mutex;
 /*global cubrid env*/
 cubrid_env_t cub_httpd_env;
 
+static void put_uuid (Json::Value &response, INT64 uuid);
+
 /**
  * @brief initial monitoring stat information
  *
@@ -455,13 +457,61 @@ cub_cm_extend_request (Json::Value &request, Json::Value &response)
   return 0;
 }
 
+/*
+ * task names that a client may run with "async":"yes". these are the
+ * handful of utility-wrapping tasks that are known to run long enough
+ * (compactdb, backupdb, ...) that blocking the caller for the whole
+ * duration is undesirable. any other task ignores the "async" key and
+ * runs the same way it always has.
+ */
+static const char *async_capable_tasks[] =
+{
+  "loaddb",
+  "unloaddb",
+  "createdb",
+  "optimizedb",
+  "checkdb",
+  "copydb",
+  "renamedb",
+  "compactdb",
+  "restoredb",
+  "backupdb",
+  "addvoldb",
+  "backupdb",
+  NULL
+};
+
+static bool
+is_async_capable_task (const string &task_name)
+{
+  for (int i = 0; async_capable_tasks[i] != NULL; i++)
+    {
+      if (task_name == async_capable_tasks[i])
+        {
+          return true;
+        }
+    }
+
+  return false;
+}
+
+/*
+ * an async job is dropped sco.iAsyncJobTtlSec seconds after it was
+ * created (default DEFAULT_ASYNC_JOB_TTL_SEC / 60 min, overridable via
+ * "async_job_ttl_sec" in cm.conf) regardless of how many times a
+ * client has polled gettaskstatus for it in the meantime, so
+ * request_list can't grow without bound just because a client stopped
+ * polling.
+ */
+
 class async_request
 {
   public:
-    unsigned int uuid;
+    INT64 uuid;
     Json::Value request;
     Json::Value response;
     int status;
+    time_t created_at;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
@@ -469,6 +519,42 @@ class async_request
 };
 
 list < async_request * >request_list;
+
+/*
+ * reap_stale_async_jobs () - drop finished jobs that have been sitting in
+ *   request_list for longer than sco.iAsyncJobTtlSec because the client
+ *   never called gettaskstatus / job_status to collect the result.
+ *   jobs that are still running are left alone no matter how old, since
+ *   we have no safe way to cancel the worker thread underneath them.
+ *
+ *   caller must already hold cm_mutex.
+ */
+static void
+reap_stale_async_jobs (void)
+{
+  time_t now = time (NULL);
+  list < async_request * >::iterator itor = request_list.begin ();
+
+  while (itor != request_list.end ())
+    {
+      if ((*itor)->status != 0 && (now - (*itor)->created_at) > sco.iAsyncJobTtlSec)
+        {
+	  async_request *stale = *itor;
+	  itor = request_list.erase (itor);
+#ifndef WINDOWS
+	  pthread_mutex_destroy (stale->mutex);
+	  pthread_cond_destroy (stale->cond);
+	  delete stale->mutex;
+	  delete stale->cond;
+#endif
+	  delete stale;
+        }
+      else
+        {
+	  ++itor;
+        }
+    }
+}
 
 #ifdef WINDOWS
 DWORD WINAPI
@@ -495,7 +581,7 @@ cm_async_request_handler (void *lpArg)
     }
   catch (exception &e)
     {
-      response["status"] = ERR_REQUEST_FORMAT;
+      response["status"] = STATUS_FAILURE;
       response["note"] = e.what ();
     }
 
@@ -515,12 +601,12 @@ cm_async_request_handler (void *lpArg)
 #ifdef WINDOWS
 int
 cm_execute_request_async (Json::Value &request, Json::Value &response,
-                          unsigned long time_out = 600)
+                          unsigned long time_out = 600, bool no_wait = false)
 {
   HANDLE hHandles;
   DWORD ThreadID;
   DWORD dwWaitResult;
-  static unsigned int req_id = 0;
+  static INT64 req_id = 0;
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
@@ -529,7 +615,10 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   pstmt->request = request;
   pstmt->status = 0;
+  pstmt->created_at = time (NULL);
+  mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
+  mutex_unlock (cm_mutex);
 
   hHandles =
     CreateThread (NULL, 0, cm_async_request_handler, pstmt, 0, &ThreadID);
@@ -540,6 +629,21 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
                                   "failed to execute task");
     }
 
+  if (no_wait)
+    {
+      /* caller asked for "async":"yes": hand the uuid back right away
+       * and let the worker thread keep running in the background. */
+      CloseHandle (hHandles);
+      mutex_lock (cm_mutex);
+      reap_stale_async_jobs ();
+      request_list.push_back (pstmt);
+      mutex_unlock (cm_mutex);
+
+      put_uuid (response, pstmt->uuid);
+      response["job-status"] = "running";
+      return build_server_header (response, ERR_NO_ERROR, "none");
+    }
+
   //dwWaitResult = WaitForSingleObject (hHandles, time_out * 1000);    //  time-out interval
 
   dwWaitResult = WaitForSingleObject (hHandles, INFINITE);    //no timeout.
@@ -547,8 +651,12 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   if (dwWaitResult == WAIT_TIMEOUT)
     {
       CloseHandle (hHandles);
+      mutex_lock (cm_mutex);
+      reap_stale_async_jobs ();
       request_list.push_back (pstmt);
-      response["uuid"] = pstmt->uuid;
+      mutex_unlock (cm_mutex);
+      put_uuid (response, pstmt->uuid);
+      response["job-status"] = "running";
       return build_server_header (response, ERR_WITH_MSG, "timeout");
     }
 
@@ -560,46 +668,60 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 #else
 int
 cm_execute_request_async (Json::Value &request, Json::Value &response,
-                          unsigned long time_out = 600)
+                          unsigned long time_out = 600, bool no_wait = false)
 {
   int err = 0;
   pthread_t async_thrd;
 #if defined(AIX)
   pthread_attr_t thread_attr;
 #endif
-  pthread_cond_t cond;
-  pthread_mutex_t mutex;
   timespec to;
-  static unsigned int req_id = 0;
+  static INT64 req_id = 0;
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
       return ERR_MEM_ALLOC;
     }
 
-  err = pthread_mutex_init (&mutex, NULL);
+  /* pstmt->mutex / pstmt->cond must outlive this function: when the
+   * caller does not wait (no_wait, or a timeout happens below) pstmt is
+   * handed off to request_list and the worker thread signals it long
+   * after this stack frame is gone. stack-allocating them here (as this
+   * function used to) left the worker thread locking/broadcasting on
+   * freed stack memory once we returned without joining it. */
+  pstmt->mutex = new pthread_mutex_t;
+  pstmt->cond = new pthread_cond_t;
+
+  err = pthread_mutex_init (pstmt->mutex, NULL);
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread mutex.");
+      delete pstmt->mutex;
+      delete pstmt->cond;
+      delete (pstmt);
       return build_server_header (response, ERR_WITH_MSG,
                                   "failed to run task.");
     }
 
-  err = pthread_cond_init (&cond, NULL);
+  err = pthread_cond_init (pstmt->cond, NULL);
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread condition.");
+      pthread_mutex_destroy (pstmt->mutex);
+      delete pstmt->mutex;
+      delete pstmt->cond;
+      delete (pstmt);
       return build_server_header (response, ERR_WITH_MSG,
                                   "failed to run task.");
     }
 
   pstmt->request = request;
   pstmt->status = 0;
+  pstmt->created_at = time (NULL);
 
+  mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
-
-  pstmt->mutex = &mutex;
-  pstmt->cond = &cond;
+  mutex_unlock (cm_mutex);
 
 #if defined(AIX)
   err = pthread_attr_init (&thread_attr);
@@ -644,19 +766,42 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   if (err != 0)
     {
+      pthread_mutex_destroy (pstmt->mutex);
+      pthread_cond_destroy (pstmt->cond);
+      delete pstmt->mutex;
+      delete pstmt->cond;
       delete (pstmt);
-      pthread_mutex_destroy (&mutex);
-      pthread_cond_destroy (&cond);
       LOG_ERROR ("cm_execute_request_async : fail to create thread.");
       return build_server_header (response, ERR_WITH_MSG,
                                   "failed to run task.");
     }
-  pthread_mutex_lock (&mutex);
+
+  /* the thread is never pthread_join ()-ed (the no_wait and timeout
+   * paths below return without waiting for it), so detach it up front;
+   * otherwise it stays joinable forever and its resources are never
+   * released. */
+  pthread_detach (async_thrd);
+
+  if (no_wait)
+    {
+      /* caller asked for "async":"yes": hand the uuid back right away
+       * and let the worker thread keep running in the background. */
+      mutex_lock (cm_mutex);
+      reap_stale_async_jobs ();
+      request_list.push_back (pstmt);
+      mutex_unlock (cm_mutex);
+
+      put_uuid (response, pstmt->uuid);
+      response["job-status"] = "running";
+      return build_server_header (response, ERR_NO_ERROR, "none");
+    }
+
+  pthread_mutex_lock (pstmt->mutex);
   to.tv_sec = time (NULL) + time_out;
   to.tv_nsec = 0;
-  err = pthread_cond_timedwait (&cond, &mutex, &to);
+  err = pthread_cond_timedwait (pstmt->cond, pstmt->mutex, &to);
 //  err = pthread_cond_wait (&cond, &mutex);
-  pthread_mutex_unlock (&mutex);
+  pthread_mutex_unlock (pstmt->mutex);
   if (err == ETIMEDOUT)
     {
       string dbname, task_name;
@@ -664,27 +809,85 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       task_name = request.get ("task", "unknown").asString();
       dbname = request.get ("dbname", "").asString();
 
-      response["uuid"] = pstmt->uuid;
+      /* register the still-running job so gettaskstatus / job_status can
+       * find it later. the original code returned here without ever
+       * push_back ()-ing pstmt, which meant a poll for this uuid always
+       * came back "uuid not found" and pstmt (plus its thread) leaked. */
+      mutex_lock (cm_mutex);
+      reap_stale_async_jobs ();
+      request_list.push_back (pstmt);
+      mutex_unlock (cm_mutex);
+
+      put_uuid (response, pstmt->uuid);
+      response["job-status"] = "running";
       LOG_ERROR ("cm_execute_request_async : Timeout %ld secs: task '%s'. %s",
 		time_out, task_name.c_str(), dbname.c_str ());
       return build_server_header (response, ERR_WITH_MSG, "timeout");
     }
 
-  pthread_join (async_thrd, NULL);
-
-  pthread_mutex_destroy (&mutex);
-  pthread_cond_destroy (&cond);
+  pthread_mutex_destroy (pstmt->mutex);
+  pthread_cond_destroy (pstmt->cond);
+  delete pstmt->mutex;
+  delete pstmt->cond;
   response = pstmt->response;
   delete (pstmt);
   return ERR_NO_ERROR;
 }
 #endif
 
+static bool
+parse_uuid (const Json::Value &v, INT64 &out)
+{
+  if (v.isIntegral ())
+    {
+      out = v.asUInt ();
+      return true;
+    }
+
+  if (v.isString ())
+    {
+      const string s = v.asString ();
+      if (s.empty ())
+        {
+	  return false;
+        }
+
+      char *endptr = NULL;
+      /* strtoull (not strtoul): on Windows "unsigned long" is only 32
+       * bits, which would silently truncate a uuid here even though
+       * req_id/out are a full 64-bit INT64. */
+      unsigned long long parsed = strtoull (s.c_str (), &endptr, 10);
+      if (endptr == s.c_str () || *endptr != '\0')
+        {
+	  return false;
+        }
+
+      out = (INT64) parsed;
+      return true;
+    }
+
+  return false;
+}
+
+/*
+ * cub_check_async_status () - handle a "gettaskstatus"
+ *   poll for a job previously started with "async":"yes" (or one that
+ *   fell back to async because it ran past sco.iHttpTimeout).
+ *
+ *   accepts the "uuid" while the job is still running this reports
+ *   job-status:"running" via a normal
+ *   ERR_NO_ERROR response instead of the previous ERR_WITH_MSG
+ *   "task not return", since "still running" is an expected poll
+ *   outcome, not a failure.
+ *
+ *   caller (cub_cm_request_handler) is expected to already hold
+ *   cm_mutex when calling this, same as before.
+ */
 int
 cub_check_async_status (Json::Value &request, Json::Value &response)
 {
   string task;
-  unsigned int uuid;
+  INT64 uuid;
   list < async_request * >::iterator itor;
   task = request["task"].asString ();
 
@@ -692,11 +895,14 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
     {
       return 0;
     }
-  if (request["uuid"] == Json::Value::null || !request["uuid"].isInt ())
+
+  reap_stale_async_jobs ();
+
+  if (!parse_uuid (request["uuid"], uuid))
     {
       return build_server_header (response, ERR_WITH_MSG, "invalid uuid");
     }
-  uuid = request["uuid"].asInt ();
+
   for (itor = request_list.begin (); itor != request_list.end (); itor++)
     {
       if ((*itor)->uuid != uuid)
@@ -712,12 +918,26 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
 
   if ((*itor)->status == 0)
     {
-      return build_server_header (response, ERR_WITH_MSG, "task not return");
+      put_uuid (response, (*itor)->uuid);
+      response["job-status"] = "running";
+      return build_server_header (response, ERR_NO_ERROR, "none");
     }
+
+  /* NOTE: a finished job is intentionally left in request_list here,
+   * not erased/deleted on this first successful poll - a client is
+   * free to call gettaskstatus for the same uuid more than once (e.g.
+   * a status-check retry, or more than one part of the client polling
+   * independently) and should keep getting the same finished result
+   * each time. the job is only ever reclaimed by reap_stale_async_jobs
+   * (), once sco.iAsyncJobTtlSec seconds have passed since it was
+   * created (see cm.conf's "async_job_ttl_sec"). */
   response = (*itor)->response;
-  request_list.erase (itor);
+  put_uuid (response, (*itor)->uuid);
+  response["job-status"] = (response["status"].isString () &&
+			    response["status"].asString () == STATUS_SUCCESS) ? "success" : "error";
   return ERR_NO_ERROR;
 }
+
 
 int
 cub_cm_request_handler (Json::Value &request, Json::Value &response)
@@ -755,8 +975,44 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
       mutex_unlock (cm_mutex);
       return 1;
     }
-  cm_execute_request_async (request, response, sco.iHttpTimeout);
 
-  mutex_unlock (cm_mutex);
+  /*
+   * everything above this point is fast and bounded (token/auth lookup,
+   * a request_list scan), so it is fine to run it under cm_mutex. what
+   * follows is not: cm_execute_request_async () either runs the task
+   * and waits for it (up to sco.iHttpTimeout, 30 sec by default) or, for
+   * an explicit "async":"yes" request on a long-running task, does not
+   * wait at all. cm_mutex used to stay held for that entire wait, which
+   * meant one client's slow compactdb/backupdb/etc. blocked every other
+   * client's requests - even unrelated, fast ones - for as long as the
+   * first one took (or until it timed out). release the lock before
+   * that call; cm_execute_request_async () re-takes cm_mutex itself,
+   * briefly, only when it actually needs to touch request_list.
+   */
+  {
+    bool want_async = uStringEqual (request.get ("async", "no").asString ().c_str (), "yes")
+                      && is_async_capable_task (request["task"].asString ());
+
+    mutex_unlock (cm_mutex);
+    cm_execute_request_async (request, response, sco.iHttpTimeout, want_async);
+  }
+
   return 1;
+}
+
+/*
+ * put_uuid () - write a job's uuid into a response as a JSON string.
+ *   the vendored jsoncpp in this tree predates 64-bit JSON number
+ *   support (Json::Value only has a 32-bit Int/UInt, no Int64/UInt64),
+ *   so assigning an INT64 uuid straight into a Json::Value would
+ *   silently truncate it once req_id grows past 2^32. encoding it as a
+ *   string sidesteps that and round-trips losslessly through
+ *   parse_uuid (), which already accepts numeric strings.
+ */
+static void
+put_uuid (Json::Value &response, INT64 uuid)
+{
+  char buf[32];
+  snprintf (buf, sizeof (buf), "%lld", (long long) uuid);
+  response["uuid"] = buf;
 }

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -622,6 +622,7 @@ class async_request
     int status;
     time_t finished_at;
     std::string db_name;
+    std::string requester_id;
     bool holds_async_slot;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
@@ -804,6 +805,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->status = 0;
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
+  pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
@@ -988,6 +990,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->status = 0;
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
+  pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
 
   mutex_lock (cm_mutex);
@@ -1153,6 +1156,11 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
   if (itor == request_list.end ())
     {
       return build_server_header (response, ERR_WITH_MSG, "uuid not found");
+    }
+
+  if (request.get ("_ID", "").asString () != itor->second->requester_id)
+    {
+      return build_server_header (response, ERR_WITH_MSG, "invalid uuid");
     }
 
   if (itor->second->status == 0)

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -843,7 +843,13 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 static bool
 parse_uuid (const Json::Value &v, INT64 &out)
 {
-  if (v.isIntegral ())
+  if (v.isInt ())
+    {
+      out = v.asInt ();
+      return true;
+    }
+
+  if (v.isUInt ())
     {
       out = v.asUInt ();
       return true;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -647,9 +647,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       return build_server_header (response, ERR_NO_ERROR, "none");
     }
 
-  //dwWaitResult = WaitForSingleObject (hHandles, time_out * 1000);    //  time-out interval
-
-  dwWaitResult = WaitForSingleObject (hHandles, INFINITE);    //no timeout.
+  dwWaitResult = WaitForSingleObject (hHandles, time_out * 1000);    //  time-out interval
 
   if (dwWaitResult == WAIT_TIMEOUT)
     {

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -614,6 +614,7 @@ class async_request
     std::string db_name;
     std::string requester_id;
     bool holds_async_slot;
+    bool max_running_warned;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
@@ -626,6 +627,7 @@ std::map < INT64, async_request * > request_list;
  * reap_stale_async_jobs () - drop finished jobs that have been sitting in
  *   request_list for longer than sco.iAsyncJobTtlSec because the client
  *   never called gettaskstatus / job_status to collect the result.
+ *   a job still in progress (status == 0) is never removed here.
  *
  *   caller must already hold cm_mutex.
  */
@@ -652,18 +654,20 @@ reap_stale_async_jobs (void)
           continue;
         }
 
-      if (cur->status == 0 && (now - cur->created_at) > sco.iAsyncJobMaxRunningSec)
+      if (cur->status == 0 && !cur->max_running_warned
+          && (now - cur->created_at) > sco.iAsyncJobMaxRunningSec)
         {
           string task_name = cur->request.get ("task", "unknown").asString ();
 
-          LOG_ERROR ("reap_stale_async_jobs : job %lld (task '%s', db '%s') exceeded "
-                     "async_job_max_running_sec (%d > %d sec) and was dropped from "
-                     "request_list.",
+          LOG_ERROR ("reap_stale_async_jobs : job %lld (task '%s', db '%s') has been "
+                     "running for %d sec, past async_job_max_running_sec (%d sec); "
+                     "its worker thread cannot be safely cancelled, so it is being "
+                     "left in request_list until it actually finishes.",
                      (long long) cur->uuid, task_name.c_str (), cur->db_name.c_str (),
                      (int) (now - cur->created_at), sco.iAsyncJobMaxRunningSec);
 
-          itor = request_list.erase (itor);
-          continue;
+          /* log this only once per job, not on every reap_stale_async_jobs () call */
+          cur->max_running_warned = true;
         }
 
       ++itor;
@@ -810,6 +814,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
+  pstmt->max_running_warned = false;
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
@@ -996,6 +1001,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();
   pstmt->holds_async_slot = no_wait;
+  pstmt->max_running_warned = false;
 
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -828,35 +828,6 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       return build_server_header (response, ERR_WITH_MSG, "timeout");
     }
 
-  pthread_mutex_lock (pstmt->mutex);
-  to.tv_sec = time (NULL) + time_out;
-  to.tv_nsec = 0;
-  err = pthread_cond_timedwait (pstmt->cond, pstmt->mutex, &to);
-//  err = pthread_cond_wait (&cond, &mutex);
-  pthread_mutex_unlock (pstmt->mutex);
-  if (err == ETIMEDOUT)
-    {
-      string dbname, task_name;
-
-      task_name = request.get ("task", "unknown").asString();
-      dbname = request.get ("dbname", "").asString();
-
-      /* register the still-running job so gettaskstatus / job_status can
-       * find it later. the original code returned here without ever
-       * push_back ()-ing pstmt, which meant a poll for this uuid always
-       * came back "uuid not found" and pstmt (plus its thread) leaked. */
-      mutex_lock (cm_mutex);
-      reap_stale_async_jobs ();
-      request_list.push_back (pstmt);
-      mutex_unlock (cm_mutex);
-
-      put_uuid (response, pstmt->uuid);
-      response["job-status"] = "running";
-      LOG_ERROR ("cm_execute_request_async : Timeout %ld secs: task '%s'. %s",
-		time_out, task_name.c_str(), dbname.c_str ());
-      return build_server_header (response, ERR_WITH_MSG, "timeout");
-    }
-
   pthread_mutex_destroy (pstmt->mutex);
   pthread_cond_destroy (pstmt->cond);
   delete pstmt->mutex;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -47,8 +47,6 @@ using namespace std;
 #define MAX_PATH 256
 #endif
 
-extern T_EMGR_VERSION CLIENT_VERSION;
-
 typedef struct
 {
   char cubrid[MAX_PATH];              /*cubrid home; CUBRID=/root/CUBRID */
@@ -214,7 +212,6 @@ ch_process_request (nvplist *req, nvplist *res)
   char access_log_flag;
   char _dbmt_error[DBMT_ERROR_MSG_SIZE];
   int major_ver, minor_ver;
-  char *cli_ver;
 
   int elapsed_msec = 0;
   struct timeval task_begin, task_end;
@@ -264,12 +261,6 @@ ch_process_request (nvplist *req, nvplist *res)
         }
     }
 
-  /* set CLIENT_VERSION */
-  cli_ver = nv_get_val (req, "_CLIENT_VERSION");
-  make_version_info (cli_ver == NULL ? "1.0" : cli_ver, &major_ver,
-                     &minor_ver);
-  CLIENT_VERSION = EMGR_MAKE_VER (major_ver, minor_ver);    /* global variable */
-
   sprintf (_dbmt_error, "?");    /* prevent to have null string */
   if (task_code == TS_UNDEFINED)
     {
@@ -314,8 +305,6 @@ ch_process_request (nvplist *req, nvplist *res)
     }
 
   uGenerateStatus (req, res, retval, _dbmt_error);
-
-  //      FREE_MEM (cli_ver);
 
   return 0;
 }

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -665,11 +665,14 @@ reap_stale_async_jobs (void)
 
       if (cur->status == 0 && (now - cur->created_at) > sco.iAsyncJobMaxRunningSec)
         {
-          if (cur->holds_async_slot)
-            {
-              async_job_slot_release ();
-              cur->holds_async_slot = false;
-            }
+          string task_name = cur->request.get ("task", "unknown").asString ();
+
+          LOG_ERROR ("reap_stale_async_jobs : job %lld (task '%s', db '%s') exceeded "
+                     "async_job_max_running_sec (%d > %d sec) and was dropped from "
+                     "request_list.",
+                     (long long) cur->uuid, task_name.c_str (), cur->db_name.c_str (),
+                     (int) (now - cur->created_at), sco.iAsyncJobMaxRunningSec);
+
           itor = request_list.erase (itor);
           continue;
         }

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <map>
+#include <atomic>
 
 #ifdef WINDOWS
 #include <process.h>
@@ -172,7 +173,7 @@ cub_cm_destory_env ()
 int
 ch_build_request (Json::Value &req, nvplist *cli_request)
 {
-  static int i = 0;
+  static std::atomic <unsigned int> i (0);
   nv_add_nvp_int (cli_request, "_STAMP", i++);
   nv_add_nvp (cli_request, "_PROGNAME", CMS_NAME);
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -539,19 +539,19 @@ reap_stale_async_jobs (void)
     {
       if ((*itor)->status != 0 && (now - (*itor)->finished_at) > sco.iAsyncJobTtlSec)
         {
-	  async_request *stale = *itor;
-	  itor = request_list.erase (itor);
+          async_request *stale = *itor;
+          itor = request_list.erase (itor);
 #ifndef WINDOWS
-	  pthread_mutex_destroy (stale->mutex);
-	  pthread_cond_destroy (stale->cond);
-	  delete stale->mutex;
-	  delete stale->cond;
+          pthread_mutex_destroy (stale->mutex);
+          pthread_cond_destroy (stale->cond);
+          delete stale->mutex;
+          delete stale->cond;
 #endif
-	  delete stale;
+          delete stale;
         }
       else
         {
-	  ++itor;
+          ++itor;
         }
     }
 }
@@ -818,7 +818,7 @@ parse_uuid (const Json::Value &v, INT64 &out)
       const string s = v.asString ();
       if (s.empty ())
         {
-	  return false;
+          return false;
         }
 
       char *endptr = NULL;
@@ -832,7 +832,7 @@ parse_uuid (const Json::Value &v, INT64 &out)
 #endif
       if (endptr == s.c_str () || *endptr != '\0')
         {
-	  return false;
+          return false;
         }
 
       out = (INT64) parsed;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1005,7 +1005,9 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
    * briefly, only when it actually needs to touch request_list.
    */
   {
-    bool want_async = uStringEqual (request.get ("async", "no").asString ().c_str (), "yes")
+    const Json::Value &async_val = request.get ("async", "no");
+    bool want_async = async_val.isString ()
+                      && uStringEqual (async_val.asString ().c_str (), "yes")
                       && is_async_capable_task (request["task"].asString ());
 
     mutex_unlock (cm_mutex);

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -593,15 +593,6 @@ build_async_task_limit_response (Json::Value &response)
   return build_server_header (response, ERR_WITH_MSG, note);
 }
 
-/*
- * an async job is dropped sco.iAsyncJobTtlSec seconds after it was
- * created (default DEFAULT_ASYNC_JOB_TTL_SEC / 60 min, overridable via
- * "async_job_ttl_sec" in cm.conf) regardless of how many times a
- * client has polled gettaskstatus for it in the meantime, so
- * request_list can't grow without bound just because a client stopped
- * polling.
- */
-
 class async_request
 {
   public:
@@ -621,11 +612,11 @@ class async_request
 #endif
 };
 
-std::map < INT64, async_request * > request_list;
+std::map < INT64, async_request * > request_map;
 
 /*
  * reap_stale_async_jobs () - drop finished jobs that have been sitting in
- *   request_list for longer than sco.iAsyncJobTtlSec because the client
+ *   request_map for longer than sco.iAsyncJobTtlSec because the client
  *   never called gettaskstatus / job_status to collect the result.
  *   a job still in progress (status == 0) is never removed here.
  *
@@ -635,15 +626,15 @@ static void
 reap_stale_async_jobs (void)
 {
   time_t now = time (NULL);
-  map < INT64, async_request * > ::iterator itor = request_list.begin ();
+  map < INT64, async_request * > ::iterator itor = request_map.begin ();
 
-  while (itor != request_list.end ())
+  while (itor != request_map.end ())
     {
       async_request *cur = itor->second;
 
       if (cur->status != 0 && (now - cur->finished_at) > sco.iAsyncJobTtlSec)
         {
-          itor = request_list.erase (itor);
+          itor = request_map.erase (itor);
 #ifndef WINDOWS
           pthread_mutex_destroy (cur->mutex);
           pthread_cond_destroy (cur->cond);
@@ -662,7 +653,7 @@ reap_stale_async_jobs (void)
           LOG_ERROR ("reap_stale_async_jobs : job %lld (task '%s', db '%s') has been "
                      "running for %d sec, past async_long_job_sec (%d sec); "
                      "its worker thread cannot be safely cancelled, so it is being "
-                     "left in request_list until it actually finishes.",
+                     "left in request_map until it actually finishes.",
                      (long long) cur->uuid, task_name.c_str (), cur->db_name.c_str (),
                      (int) (now - cur->created_at), sco.iAsyncLongJobSec);
 
@@ -848,7 +839,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       CloseHandle (hHandles);
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list[pstmt->uuid] = pstmt;
+      request_map[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
 
       put_uuid (response, pstmt->uuid);
@@ -863,7 +854,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       CloseHandle (hHandles);
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list[pstmt->uuid] = pstmt;
+      request_map[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
       put_uuid (response, pstmt->uuid);
       response["job-status"] = "running";
@@ -1046,7 +1037,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
        * and let the worker thread keep running in the background. */
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list[pstmt->uuid] = pstmt;
+      request_map[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
 
       put_uuid (response, pstmt->uuid);
@@ -1074,7 +1065,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
        */
       mutex_lock (cm_mutex);
       reap_stale_async_jobs ();
-      request_list[pstmt->uuid] = pstmt;
+      request_map[pstmt->uuid] = pstmt;
       mutex_unlock (cm_mutex);
       put_uuid (response, pstmt->uuid);
       response["job-status"] = "running";
@@ -1162,8 +1153,8 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
       return build_server_header (response, ERR_WITH_MSG, "invalid uuid");
     }
 
-  itor = request_list.find (uuid);
-  if (itor == request_list.end ())
+  itor = request_map.find (uuid);
+  if (itor == request_map.end ())
     {
       return build_server_header (response, ERR_WITH_MSG, "uuid not found");
     }
@@ -1180,7 +1171,7 @@ cub_check_async_status (Json::Value &request, Json::Value &response)
       return build_server_header (response, ERR_NO_ERROR, "none");
     }
 
-  /* NOTE: a finished job is intentionally left in request_list here,
+  /* NOTE: a finished job is intentionally left in request_map here,
    * not erased/deleted on this first successful poll - a client is
    * free to call gettaskstatus for the same uuid more than once (e.g.
    * a status-check retry, or more than one part of the client polling
@@ -1236,8 +1227,8 @@ cub_check_server_status (Json::Value &request, Json::Value &response)
   int oldest_running_sec = 0;
   Json::Value long_job_list;
 
-  for (map < INT64, async_request * >::iterator itor = request_list.begin ();
-       itor != request_list.end (); ++itor)
+  for (map < INT64, async_request * >::iterator itor = request_map.begin ();
+       itor != request_map.end (); ++itor)
     {
       async_request *cur = itor->second;
 
@@ -1271,14 +1262,14 @@ cub_check_server_status (Json::Value &request, Json::Value &response)
         }
     }
 
-  Json::Value req_list_status;
-  req_list_status["total"] = total;
-  req_list_status["running"] = running;
-  req_list_status["finished_pending_ttl"] = finished_pending_ttl;
-  req_list_status["long_jobs"] = long_jobs;
-  req_list_status["longest_task_running_sec"] = oldest_running_sec;
-  req_list_status["long_job_list"] = long_job_list;
-  response["request-list"] = req_list_status;
+  Json::Value req_map_status;
+  req_map_status["map_size"] = total;
+  req_map_status["running"] = running;
+  req_map_status["finished_pending_ttl"] = finished_pending_ttl;
+  req_map_status["long_jobs"] = long_jobs;
+  req_map_status["longest_task_running_sec"] = oldest_running_sec;
+  req_map_status["long_job_list"] = long_job_list;
+  response["request-map"] = req_map_status;
 
   Json::Value slot;
   slot["num_async_job_running"] = num_running_async_tasks;
@@ -1341,16 +1332,7 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
 
   /*
    * everything above this point is fast and bounded (token/auth lookup,
-   * a request_list scan), so it is fine to run it under cm_mutex. what
-   * follows is not: cm_execute_request_async () either runs the task
-   * and waits for it (up to sco.iHttpTimeout, 30 sec by default) or, for
-   * an explicit "async":"yes" request on a long-running task, does not
-   * wait at all. cm_mutex used to stay held for that entire wait, which
-   * meant one client's slow compactdb/backupdb/etc. blocked every other
-   * client's requests - even unrelated, fast ones - for as long as the
-   * first one took (or until it timed out). release the lock before
-   * that call; cm_execute_request_async () re-takes cm_mutex itself,
-   * briefly, only when it actually needs to touch request_list.
+   * a request_map scan), so it is fine to run it under cm_mutex.
    */
   {
     const Json::Value &async_val = request.get ("async", "no");

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1184,16 +1184,14 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
   mutex_lock (cm_mutex);
 
 
-  // leave a back door for testing...
-  if (ext_ut_validate_token (request, response) != ERR_NO_ERROR && request["token"].asString() != "test")
+  if (ext_ut_validate_token (request, response) != ERR_NO_ERROR)
     {
       response["task"] = request["task"].asString();
       mutex_unlock (cm_mutex);
       return 1;
     }
 
-  // leave a back door for testing...
-  if (!ext_ut_validate_auth (request) && request["token"].asString() != "test")
+  if (!ext_ut_validate_auth (request))
     {
       response["status"] = STATUS_FAILURE;
       response["note"] = "The user don't have authority to execute the task: " + request["task"].asString();

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -537,6 +537,26 @@ db_running_async_done (const string &dbname)
     }
 }
 
+static std::string
+db_running_async_task (const std::string &dbname)
+{
+  map <std::string, std::string> ::iterator it = db_running_async.find (dbname);
+  return (it != db_running_async.end ()) ? it->second : std::string ();
+}
+
+static int
+build_db_busy_response (Json::Value &response, const std::string &dbname,
+                        const std::string &running_task)
+{
+  string note = "database '" + dbname + "' is busy with another task";
+  if (!running_task.empty ())
+    {
+      note += " ('" + running_task + "')";
+    }
+  response["job-status"] = "rejected";
+  return build_server_header (response, ERR_WITH_MSG, note.c_str ());
+}
+
 /*
  * an async job is dropped sco.iAsyncJobTtlSec seconds after it was
  * created (default DEFAULT_ASYNC_JOB_TTL_SEC / 60 min, overridable via
@@ -686,11 +706,11 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
     {
       mutex_lock (cm_mutex);
       bool started = db_running_async_start (dbname, task_name);
+      string running_task = started ? "" : db_running_async_task (dbname);
       mutex_unlock (cm_mutex);
       if (!started)
         {
-          return build_server_header (response, ERR_WITH_MSG,
-              ("database '" + dbname + "' is busy with another operation").c_str ());
+          return build_db_busy_response (response, dbname, running_task);
         }
     }
 
@@ -787,11 +807,11 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
        */
       mutex_lock (cm_mutex);
       bool started = db_running_async_start (dbname, task_name);
+      string running_task = started ? "" : db_running_async_task (dbname);
       mutex_unlock (cm_mutex);
       if (!started)
         {
-          return build_server_header (response, ERR_WITH_MSG,
-              ("database '" + dbname + "' is busy with another operation").c_str ());
+          return build_db_busy_response (response, dbname, running_task);
         }
     }
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -868,6 +868,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->request = request;
   pstmt->status = 0;
   pstmt->created_at = time (NULL);
+  pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
 
   mutex_lock (cm_mutex);

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1195,7 +1195,6 @@ int
 cub_check_server_status (Json::Value &request, Json::Value &response)
 {
   string task = request["task"].asString ();
-  char vers[32];
 
   if (task != "getserverstatus")
     {
@@ -1215,8 +1214,7 @@ cub_check_server_status (Json::Value &request, Json::Value &response)
   time_t now = time (NULL);
 
   Json::Value conf;
-  snprintf (vers, sizeof (vers), "%d.%d", cubrid_version_major,cubrid_version_minor);
-  conf["CUBRID Version"] = vers;
+  conf["CUBRID_Version"] = cubrid_version_build;
   conf["async_job_ttl_sec"] = sco.iAsyncJobTtlSec;
   conf["async_long_job_sec"] = sco.iAsyncLongJobSec;
   conf["max_num_async_task"] = sco.iMaxNumAsyncTask;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -60,8 +60,6 @@ mutex_t cm_mutex;
 /*global cubrid env*/
 cubrid_env_t cub_httpd_env;
 
-static void put_uuid (Json::Value &response, INT64 uuid);
-
 /**
  * @brief initial monitoring stat information
  *
@@ -603,6 +601,23 @@ cm_async_request_handler (void *lpArg)
   return NULL;
 }
 
+/*
+ * put_uuid () - write a job's uuid into a response as a JSON string.
+ *   the vendored jsoncpp in this tree predates 64-bit JSON number
+ *   support (Json::Value only has a 32-bit Int/UInt, no Int64/UInt64),
+ *   so assigning an INT64 uuid straight into a Json::Value would
+ *   silently truncate it once req_id grows past 2^32. encoding it as a
+ *   string sidesteps that and round-trips losslessly through
+ *   parse_uuid (), which already accepts numeric strings.
+ */
+static void
+put_uuid (Json::Value &response, INT64 uuid)
+{
+  char buf[32];
+  snprintf (buf, sizeof (buf), "%lld", (long long) uuid);
+  response["uuid"] = buf;
+}
+
 #ifdef WINDOWS
 int
 cm_execute_request_async (Json::Value &request, Json::Value &response,
@@ -966,19 +981,3 @@ cub_cm_request_handler (Json::Value &request, Json::Value &response)
   return 1;
 }
 
-/*
- * put_uuid () - write a job's uuid into a response as a JSON string.
- *   the vendored jsoncpp in this tree predates 64-bit JSON number
- *   support (Json::Value only has a 32-bit Int/UInt, no Int64/UInt64),
- *   so assigning an INT64 uuid straight into a Json::Value would
- *   silently truncate it once req_id grows past 2^32. encoding it as a
- *   string sidesteps that and round-trips losslessly through
- *   parse_uuid (), which already accepts numeric strings.
- */
-static void
-put_uuid (Json::Value &response, INT64 uuid)
-{
-  char buf[32];
-  snprintf (buf, sizeof (buf), "%lld", (long long) uuid);
-  response["uuid"] = buf;
-}

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -492,6 +492,51 @@ is_async_capable_task (const string &task_name)
   return false;
 }
 
+static map <std::string, std::string> db_running_async;
+
+/*
+ * is_db_running_async () - pure query: is some async-capable task
+ * currently running against dbname? caller must hold cm_mutex.
+ */
+static bool
+is_db_running_async (const std::string &dbname)
+{
+  return !dbname.empty ()
+         && db_running_async.find (dbname) != db_running_async.end ();
+}
+
+/*
+ * db_running_async_start () - mark dbname as running task_name.
+ * caller must hold cm_mutex.
+ */
+static bool
+db_running_async_start (const std::string &dbname, const std::string &task_name)
+{
+  if (dbname.empty ())
+    {
+      return true;
+    }
+  if (is_db_running_async (dbname))
+    {
+      return false;
+    }
+  db_running_async[dbname] = task_name;
+  return true;
+}
+
+/*
+ * db_running_async_done () - clear dbname's running-task marker, if any.
+ *   caller must hold cm_mutex.
+ */
+static void
+db_running_async_done (const string &dbname)
+{
+  if (!dbname.empty ())
+    {
+      db_running_async.erase (dbname);
+    }
+}
+
 /*
  * an async job is dropped sco.iAsyncJobTtlSec seconds after it was
  * created (default DEFAULT_ASYNC_JOB_TTL_SEC / 60 min, overridable via
@@ -510,13 +555,14 @@ class async_request
     int status;
     time_t created_at;
     time_t finished_at;
+    std::string db_name;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
 #endif
 };
 
-map < INT64, async_request * > request_list;
+std::map < INT64, async_request * > request_list;
 
 /*
  * reap_stale_async_jobs () - drop finished jobs that have been sitting in
@@ -593,6 +639,10 @@ cm_async_request_handler (void *lpArg)
   mutex_lock (cm_mutex);
   async_param->finished_at = time (NULL);
   async_param->status = 1;
+  /* release the per-db slot (if this task took one) now that the task
+   * has actually finished running - independent of whether/when a
+   * client ever polls gettaskstatus for it. */
+  db_running_async_done (async_param->db_name);
   mutex_unlock (cm_mutex);
 #ifndef WINDOWS
   pthread_cond_broadcast (async_param->cond);
@@ -628,9 +678,31 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   DWORD ThreadID;
   DWORD dwWaitResult;
   static INT64 req_id = 0;
+  string task_name = request.get ("task", "").asString ();
+  string dbname = request.get ("dbname", "").asString ();
+  bool is_db_task = is_async_capable_task (task_name);
+
+  if (is_db_task)
+    {
+      mutex_lock (cm_mutex);
+      bool started = db_running_async_start (dbname, task_name);
+      mutex_unlock (cm_mutex);
+      if (!started)
+        {
+          return build_server_header (response, ERR_WITH_MSG,
+              ("database '" + dbname + "' is busy with another operation").c_str ());
+        }
+    }
+
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       return ERR_MEM_ALLOC;
     }
 
@@ -638,6 +710,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->status = 0;
   pstmt->created_at = time (NULL);
   pstmt->finished_at = 0;
+  pstmt->db_name = is_db_task ? dbname : "";
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
@@ -646,6 +719,12 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
     CreateThread (NULL, 0, cm_async_request_handler, pstmt, 0, &ThreadID);
   if (hHandles == NULL)
     {
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       delete (pstmt);
       return build_server_header (response, ERR_WITH_MSG,
                                   "failed to execute task");
@@ -694,18 +773,40 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pthread_t async_thrd;
   timespec to;
   static INT64 req_id = 0;
+  string task_name = request.get ("task", "").asString ();
+  string dbname = request.get ("dbname", "").asString ();
+  bool is_db_task = is_async_capable_task (task_name);
+
+  if (is_db_task)
+    {
+      /*
+       * only one async-capable task may run against a given database
+       * at a time (e.g. compactdb 'demodb' must not start while
+       * backupdb 'demodb' is still running). fail fast here, before
+       * spawning a worker thread at all, if dbname is already busy.
+       */
+      mutex_lock (cm_mutex);
+      bool started = db_running_async_start (dbname, task_name);
+      mutex_unlock (cm_mutex);
+      if (!started)
+        {
+          return build_server_header (response, ERR_WITH_MSG,
+              ("database '" + dbname + "' is busy with another operation").c_str ());
+        }
+    }
+
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       return ERR_MEM_ALLOC;
     }
 
-  /* pstmt->mutex / pstmt->cond must outlive this function: when the
-   * caller does not wait (no_wait, or a timeout happens below) pstmt is
-   * handed off to request_list and the worker thread signals it long
-   * after this stack frame is gone. stack-allocating them here (as this
-   * function used to) left the worker thread locking/broadcasting on
-   * freed stack memory once we returned without joining it. */
   pstmt->mutex = new pthread_mutex_t;
   pstmt->cond = new pthread_cond_t;
 
@@ -713,6 +814,12 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread mutex.");
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       delete pstmt->mutex;
       delete pstmt->cond;
       delete (pstmt);
@@ -724,6 +831,12 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread condition.");
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       pthread_mutex_destroy (pstmt->mutex);
       delete pstmt->mutex;
       delete pstmt->cond;
@@ -735,6 +848,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->request = request;
   pstmt->status = 0;
   pstmt->created_at = time (NULL);
+  pstmt->db_name = is_db_task ? dbname : "";
 
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
@@ -744,6 +858,12 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   if (err != 0)
     {
+      if (is_db_task)
+        {
+          mutex_lock (cm_mutex);
+          db_running_async_done (dbname);
+          mutex_unlock (cm_mutex);
+        }
       pthread_mutex_destroy (pstmt->mutex);
       pthread_cond_destroy (pstmt->cond);
       delete pstmt->mutex;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -676,9 +676,6 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 {
   int err = 0;
   pthread_t async_thrd;
-#if defined(AIX)
-  pthread_attr_t thread_attr;
-#endif
   timespec to;
   static INT64 req_id = 0;
   async_request *pstmt = (async_request *) new (async_request);
@@ -727,46 +724,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
 
-#if defined(AIX)
-  err = pthread_attr_init (&thread_attr);
-  if (err != 0)
-    {
-      LOG_ERROR ("cm_execute_request_async : fail to set thread attribute.");
-      return build_server_header (response, ERR_WITH_MSG,
-                                  "failed to run task.");
-    }
-
-  err = pthread_attr_setdetachstate (&thread_attr, PTHREAD_CREATE_DETACHED);
-  if (err != 0)
-    {
-      LOG_ERROR ("cm_execute_request_async : fail to set thread detach state.");
-      return build_server_header (response, ERR_WITH_MSG,
-                                  "failed to run task.");
-    }
-
-  /* AIX's pthread is slightly different from other systems.
-  Its performance highly depends on the pthread's scope and it's related
-  kernel parameters. */
-  err = pthread_attr_setscope (&thread_attr, PTHREAD_SCOPE_PROCESS);
-  if (err != 0)
-    {
-      LOG_ERROR ("cm_execute_request_async : fail to set thread scope.");
-      return build_server_header (response, ERR_WITH_MSG,
-                                  "failed to run task.");
-    }
-
-  err = pthread_attr_setstacksize (&thread_attr, AIX_STACKSIZE_PER_THREAD);
-  if (err != 0)
-    {
-      LOG_ERROR ("cm_execute_request_async : fail to set thread stack size.");
-      return build_server_header (response, ERR_WITH_MSG,
-                                  "failed to run task.");
-    }
-
-  err = pthread_create (&async_thrd, &thread_attr, cm_async_request_handler, pstmt);
-#else /* except AIX */
   err = pthread_create (&async_thrd, NULL, cm_async_request_handler, pstmt);
-#endif
 
   if (err != 0)
     {

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -573,7 +573,6 @@ class async_request
     Json::Value request;
     Json::Value response;
     int status;
-    time_t created_at;
     time_t finished_at;
     std::string db_name;
 #ifndef WINDOWS
@@ -728,7 +727,6 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   pstmt->request = request;
   pstmt->status = 0;
-  pstmt->created_at = time (NULL);
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
   mutex_lock (cm_mutex);
@@ -867,7 +865,6 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   pstmt->request = request;
   pstmt->status = 0;
-  pstmt->created_at = time (NULL);
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -512,6 +512,7 @@ class async_request
     Json::Value response;
     int status;
     time_t created_at;
+    time_t finished_at;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
@@ -537,7 +538,7 @@ reap_stale_async_jobs (void)
 
   while (itor != request_list.end ())
     {
-      if ((*itor)->status != 0 && (now - (*itor)->created_at) > sco.iAsyncJobTtlSec)
+      if ((*itor)->status != 0 && (now - (*itor)->finished_at) > sco.iAsyncJobTtlSec)
         {
 	  async_request *stale = *itor;
 	  itor = request_list.erase (itor);
@@ -585,6 +586,7 @@ cm_async_request_handler (void *lpArg)
       response["note"] = e.what ();
     }
 
+  async_param->finished_at = time (NULL);
   async_param->status = 1;
   nv_destroy (cli_request);
   nv_destroy (cli_response);
@@ -616,6 +618,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->request = request;
   pstmt->status = 0;
   pstmt->created_at = time (NULL);
+  pstmt->finished_at = 0;
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
@@ -794,6 +797,35 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
       put_uuid (response, pstmt->uuid);
       response["job-status"] = "running";
       return build_server_header (response, ERR_NO_ERROR, "none");
+    }
+
+  pthread_mutex_lock (pstmt->mutex);
+  to.tv_sec = time (NULL) + time_out;
+  to.tv_nsec = 0;
+  err = 0;
+  while (pstmt->status == 0 && err == 0)
+    {
+      err = pthread_cond_timedwait (pstmt->cond, pstmt->mutex, &to);
+    }
+  pthread_mutex_unlock (pstmt->mutex);
+  if (pstmt->status == 0)
+    {
+      string dbname, task_name;
+      task_name = request.get ("task", "unknown").asString();
+      dbname = request.get ("dbname", "").asString();
+      /* register the still-running job so gettaskstatus can
+       * find it later. the original code returned here without ever
+       * push_back ()-ing pstmt, which meant a poll for this uuid always
+       * came back "uuid not found" and pstmt (plus its thread) leaked. */
+      mutex_lock (cm_mutex);
+      reap_stale_async_jobs ();
+      request_list.push_back (pstmt);
+      mutex_unlock (cm_mutex);
+      put_uuid (response, pstmt->uuid);
+      response["job-status"] = "running";
+      LOG_ERROR ("cm_execute_request_async : Timeout %ld secs: task '%s'. %s",
+		time_out, task_name.c_str(), dbname.c_str ());
+      return build_server_header (response, ERR_WITH_MSG, "timeout");
     }
 
   pthread_mutex_lock (pstmt->mutex);

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -557,6 +557,53 @@ build_db_busy_response (Json::Value &response, const std::string &dbname,
   return build_server_header (response, ERR_WITH_MSG, note.c_str ());
 }
 
+static int num_running_async_tasks = 0;
+
+/*
+ * async_job_slot_try_acquire () - reserve one of the sco.iMaxNumAsyncTask
+ *   slots for a new background job. caller must hold cm_mutex.
+ */
+static bool
+async_job_slot_try_acquire (void)
+{
+  if (num_running_async_tasks >= sco.iMaxNumAsyncTask)
+    {
+      return false;
+    }
+  num_running_async_tasks++;
+  return true;
+}
+
+/*
+ * async_job_slot_release () - give back a slot reserved by
+ *   async_job_slot_try_acquire (). caller must hold cm_mutex.
+ */
+static void
+async_job_slot_release (void)
+{
+  if (num_running_async_tasks > 0)
+    {
+      num_running_async_tasks--;
+    }
+}
+
+/*
+ * build_async_task_limit_response () - reply used when a client's
+ *   "async":"yes" request is rejected because sco.iMaxNumAsyncTask
+ *   background jobs are already running.
+ */
+static int
+build_async_task_limit_response (Json::Value &response)
+{
+  char note[128];
+
+  snprintf (note, sizeof (note),
+            "maximum number of concurrent async tasks (%d) reached; try again later",
+            sco.iMaxNumAsyncTask);
+  response["job-status"] = "rejected";
+  return build_server_header (response, ERR_WITH_MSG, note);
+}
+
 /*
  * an async job is dropped sco.iAsyncJobTtlSec seconds after it was
  * created (default DEFAULT_ASYNC_JOB_TTL_SEC / 60 min, overridable via
@@ -575,6 +622,7 @@ class async_request
     int status;
     time_t finished_at;
     std::string db_name;
+    bool holds_async_slot;
 #ifndef WINDOWS
     pthread_mutex_t *mutex;
     pthread_cond_t *cond;
@@ -658,10 +706,13 @@ cm_async_request_handler (void *lpArg)
   mutex_lock (cm_mutex);
   async_param->finished_at = time (NULL);
   async_param->status = 1;
-  /* release the per-db slot (if this task took one) now that the task
-   * has actually finished running - independent of whether/when a
-   * client ever polls gettaskstatus for it. */
+
   db_running_async_done (async_param->db_name);
+
+  if (async_param->holds_async_slot)
+    {
+      async_job_slot_release ();
+    }
   mutex_unlock (cm_mutex);
 #ifndef WINDOWS
   pthread_cond_broadcast (async_param->cond);
@@ -713,13 +764,37 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
         }
     }
 
+  if (no_wait)
+    {
+      mutex_lock (cm_mutex);
+      bool acquired = async_job_slot_try_acquire ();
+      mutex_unlock (cm_mutex);
+      if (!acquired)
+        {
+          if (is_db_task)
+            {
+              mutex_lock (cm_mutex);
+              db_running_async_done (dbname);
+              mutex_unlock (cm_mutex);
+            }
+          return build_async_task_limit_response (response);
+        }
+    }
+
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       return ERR_MEM_ALLOC;
@@ -729,6 +804,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->status = 0;
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
+  pstmt->holds_async_slot = no_wait;
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
   mutex_unlock (cm_mutex);
@@ -737,10 +813,17 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
     CreateThread (NULL, 0, cm_async_request_handler, pstmt, 0, &ThreadID);
   if (hHandles == NULL)
     {
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       delete (pstmt);
@@ -813,13 +896,37 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
         }
     }
 
+  if (no_wait)
+    {
+      mutex_lock (cm_mutex);
+      bool acquired = async_job_slot_try_acquire ();
+      mutex_unlock (cm_mutex);
+      if (!acquired)
+        {
+          if (is_db_task)
+            {
+              mutex_lock (cm_mutex);
+              db_running_async_done (dbname);
+              mutex_unlock (cm_mutex);
+            }
+          return build_async_task_limit_response (response);
+        }
+    }
+
   async_request *pstmt = (async_request *) new (async_request);
   if (pstmt == NULL)
     {
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       return ERR_MEM_ALLOC;
@@ -832,10 +939,17 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread mutex.");
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       delete pstmt->mutex;
@@ -849,10 +963,17 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   if (err != 0)
     {
       LOG_ERROR ("cm_execute_request_async : fail to set thread condition.");
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       pthread_mutex_destroy (pstmt->mutex);
@@ -867,6 +988,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
   pstmt->status = 0;
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
+  pstmt->holds_async_slot = no_wait;
 
   mutex_lock (cm_mutex);
   pstmt->uuid = req_id++;
@@ -876,10 +998,17 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   if (err != 0)
     {
-      if (is_db_task)
+      if (is_db_task || no_wait)
         {
           mutex_lock (cm_mutex);
-          db_running_async_done (dbname);
+          if (is_db_task)
+            {
+              db_running_async_done (dbname);
+            }
+          if (no_wait)
+            {
+              async_job_slot_release ();
+            }
           mutex_unlock (cm_mutex);
         }
       pthread_mutex_destroy (pstmt->mutex);

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -477,7 +477,6 @@ static const char *async_capable_tasks[] =
   "restoredb",
   "backupdb",
   "addvoldb",
-  "backupdb",
   NULL
 };
 

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -807,8 +807,9 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
     {
       err = pthread_cond_timedwait (pstmt->cond, pstmt->mutex, &to);
     }
+  bool finished = (pstmt->status != 0);
   pthread_mutex_unlock (pstmt->mutex);
-  if (pstmt->status == 0)
+  if (!finished)
     {
       string dbname, task_name;
       task_name = request.get ("task", "unknown").asString();

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -1281,8 +1281,8 @@ cub_check_server_status (Json::Value &request, Json::Value &response)
   response["request-list"] = req_list_status;
 
   Json::Value slot;
-  slot["in_use"] = num_running_async_tasks;
-  slot["max"] = sco.iMaxNumAsyncTask;
+  slot["num_async_job_running"] = num_running_async_tasks;
+  slot["max_async_job"] = sco.iMaxNumAsyncTask;
   response["async-slot"] = slot;
 
   Json::Value db_busy;

--- a/server/src/cm_server_interface.cpp
+++ b/server/src/cm_server_interface.cpp
@@ -620,6 +620,7 @@ class async_request
     Json::Value request;
     Json::Value response;
     int status;
+    time_t created_at;
     time_t finished_at;
     std::string db_name;
     std::string requester_id;
@@ -636,8 +637,6 @@ std::map < INT64, async_request * > request_list;
  * reap_stale_async_jobs () - drop finished jobs that have been sitting in
  *   request_list for longer than sco.iAsyncJobTtlSec because the client
  *   never called gettaskstatus / job_status to collect the result.
- *   jobs that are still running are left alone no matter how old, since
- *   we have no safe way to cancel the worker thread underneath them.
  *
  *   caller must already hold cm_mutex.
  */
@@ -650,6 +649,7 @@ reap_stale_async_jobs (void)
   while (itor != request_list.end ())
     {
       async_request *cur = itor->second;
+
       if (cur->status != 0 && (now - cur->finished_at) > sco.iAsyncJobTtlSec)
         {
           itor = request_list.erase (itor);
@@ -660,11 +660,21 @@ reap_stale_async_jobs (void)
           delete cur->cond;
 #endif
           delete cur;
+          continue;
         }
-      else
+
+      if (cur->status == 0 && (now - cur->created_at) > sco.iAsyncJobMaxRunningSec)
         {
-          ++itor;
+          if (cur->holds_async_slot)
+            {
+              async_job_slot_release ();
+              cur->holds_async_slot = false;
+            }
+          itor = request_list.erase (itor);
+          continue;
         }
+
+      ++itor;
     }
 }
 
@@ -803,6 +813,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   pstmt->request = request;
   pstmt->status = 0;
+  pstmt->created_at = time (NULL);
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();
@@ -988,6 +999,7 @@ cm_execute_request_async (Json::Value &request, Json::Value &response,
 
   pstmt->request = request;
   pstmt->status = 0;
+  pstmt->created_at = time (NULL);
   pstmt->finished_at = 0;
   pstmt->db_name = is_db_task ? dbname : "";
   pstmt->requester_id = request.get ("_ID", "").asString ();

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -3118,6 +3118,20 @@ _free_envp (char **merged)
   free (merged);
 }
 
+/*
+ * _reap_child_async (), blocks in waitpid () for exactly one child
+ */
+static void *
+_reap_child_async (void *arg)
+{
+  pid_t *pid_ptr = (pid_t *) arg;
+  pid_t pid = *pid_ptr;
+
+  delete pid_ptr;
+  waitpid (pid, NULL, 0);
+  return NULL;
+}
+
 int
 run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
               char *stderr_file, const char *envp[], int *exit_status)
@@ -3131,14 +3145,7 @@ run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, 
   if (envp != NULL)
     {
       merged_envp = _merge_envp (envp);
-      /* on OOM, merged_envp stays NULL and the child just inherits the
-       * parent's environment unchanged -- same as run_child (). */
     }
-
-  if (wait_flag)
-    signal (SIGCHLD, SIG_DFL);
-  else
-    signal (SIGCHLD, SIG_IGN);
 
   pid = fork ();
   if (pid == 0)
@@ -3207,6 +3214,18 @@ run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, 
     }
   else
     {
+      pthread_t reaper;
+      pid_t *reap_pid = new pid_t (pid);
+
+      if (pthread_create (&reaper, NULL, _reap_child_async, reap_pid) == 0)
+       {
+         pthread_detach (reaper);
+       }
+      else
+       {
+         delete reap_pid;
+         waitpid (pid, NULL, 0);
+       }
       return pid;
     }
 }

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -2901,7 +2901,7 @@ _build_env_block (const char *const envp[])
  */
 int
 run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
-              char *stderr_file, const char *envp[], int *exit_status)
+              char *stderr_file, int *exit_status, const char *envp[])
 {
   int new_pid;
   STARTUPINFO start_info;
@@ -3134,7 +3134,7 @@ _reap_child_async (void *arg)
 
 int
 run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
-              char *stderr_file, const char *envp[], int *exit_status)
+              char *stderr_file, int *exit_status, const char *envp[])
 {
   int pid;
   char **merged_envp = NULL;

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -1062,6 +1062,7 @@ ut_get_dblist (nvplist *res, char dbdir_flag)
   struct hostent *hp;
   unsigned char ip_addr[4];
   char *token = NULL;
+  char *saveptr;
 
   snprintf (file, PATH_MAX - 1, "%s/%s", sco.szCubrid_databases,
             CUBRID_DATABASE_TXT);
@@ -1089,8 +1090,8 @@ ut_get_dblist (nvplist *res, char dbdir_flag)
           continue;
         }
 
-      for (token = strtok (dbinfo[2], ":"); token != NULL;
-           token = strtok (NULL, ":"))
+      for (token = STRTOK (dbinfo[2], ":", &saveptr); token != NULL;
+           token = STRTOK (NULL, ":", &saveptr))
         {
           if ((hp = gethostbyname (token)) == NULL)
             {

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -2798,10 +2798,6 @@ _build_env_block (const char *const envp[])
   size_t merged_size;
   int extra_count, j;
 
-  /* GetEnvironmentStrings ()/FreeEnvironmentStrings () bracket a snapshot of
-   * the live Win32 environment block; hold the lock across that snapshot so
-   * it can't be torn by a concurrent _putenv ()/SetEnvironmentVariable ()
-   * on another thread. */
   env_mutex_lock ();
 
   base_block = GetEnvironmentStrings ();

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -2734,6 +2734,485 @@ ut_run_child (const char *bin_path, const char *const argv[], int wait_flag,
 }
 #endif
 
+/*
+ * _env_mutex () - the lock behind env_mutex_lock ()/env_mutex_unlock ().
+ *
+ */
+static mutex_t *
+_env_mutex (void)
+{
+  struct env_mutex_holder
+  {
+    mutex_t m;
+
+    env_mutex_holder (void)
+    {
+      mutex_init (m);
+    }
+    ~env_mutex_holder (void)
+    {
+      mutex_destory (m);
+    }
+  };
+  static env_mutex_holder holder;
+
+  return &holder.m;
+}
+
+/*
+ * env_mutex_lock ()/env_mutex_unlock () - the lock run_child_env () holds
+ * while it snapshots the process environment (see cm_server_util.cpp).
+ */
+void
+env_mutex_lock (void)
+{
+  mutex_lock (*_env_mutex ());
+}
+
+void
+env_mutex_unlock (void)
+{
+  mutex_unlock (*_env_mutex ());
+}
+
+/*
+ * _env_key_len () - length of the "KEY" part of a "KEY=VALUE" string
+ *                    (or the whole string, if there is no '=').
+ */
+static size_t
+_env_key_len (const char *kv)
+{
+  const char *eq = strchr (kv, '=');
+
+  return (eq != NULL) ? (size_t) (eq - kv) : strlen (kv);
+}
+
+#if defined(WINDOWS)
+
+/*
+ * _build_env_block () - build a Windows environment block (a sequence of
+ * NUL-terminated "KEY=VALUE" strings, terminated by an extra NUL)
+ */
+static char *
+_build_env_block (const char *const envp[])
+{
+  char *base_block;
+  char *merged_block;
+  const char *p;
+  char *q;
+  size_t merged_size;
+  int extra_count, j;
+
+  /* GetEnvironmentStrings ()/FreeEnvironmentStrings () bracket a snapshot of
+   * the live Win32 environment block; hold the lock across that snapshot so
+   * it can't be torn by a concurrent _putenv ()/SetEnvironmentVariable ()
+   * on another thread. */
+  env_mutex_lock ();
+
+  base_block = GetEnvironmentStrings ();
+  if (base_block == NULL)
+    {
+      env_mutex_unlock ();
+      return NULL;
+    }
+
+  for (extra_count = 0; envp != NULL && envp[extra_count] != NULL; extra_count++)
+    ;
+
+  /* pass 1: compute the merged block size, skipping any base entry that
+   * envp[] overrides (Windows env var names are case-insensitive) */
+  merged_size = 0;
+  for (p = base_block; *p != '\0'; p += strlen (p) + 1)
+    {
+      size_t key_len = _env_key_len (p);
+      int overridden = 0;
+
+      for (j = 0; j < extra_count; j++)
+       {
+         if (key_len == _env_key_len (envp[j]) && _strnicmp (p, envp[j], key_len) == 0)
+           {
+             overridden = 1;
+             break;
+           }
+       }
+
+      if (!overridden)
+       {
+         merged_size += strlen (p) + 1;
+       }
+    }
+  for (j = 0; j < extra_count; j++)
+    {
+      merged_size += strlen (envp[j]) + 1;
+    }
+  merged_size += 1;    /* final block-terminating NUL */
+
+  merged_block = (char *) malloc (merged_size);
+  if (merged_block == NULL)
+    {
+      FreeEnvironmentStrings (base_block);
+      env_mutex_unlock ();
+      return NULL;
+    }
+
+  /* pass 2: copy */
+  q = merged_block;
+  for (p = base_block; *p != '\0'; p += strlen (p) + 1)
+    {
+      size_t len = strlen (p);
+      size_t key_len = _env_key_len (p);
+      int overridden = 0;
+
+      for (j = 0; j < extra_count; j++)
+       {
+         if (key_len == _env_key_len (envp[j]) && _strnicmp (p, envp[j], key_len) == 0)
+           {
+             overridden = 1;
+             break;
+           }
+       }
+
+      if (!overridden)
+       {
+         memcpy (q, p, len + 1);
+         q += len + 1;
+       }
+    }
+  for (j = 0; j < extra_count; j++)
+    {
+      size_t len = strlen (envp[j]);
+
+      memcpy (q, envp[j], len + 1);
+      q += len + 1;
+    }
+  *q = '\0';
+
+  FreeEnvironmentStrings (base_block);
+  env_mutex_unlock ();
+
+  return merged_block;
+}
+
+/*
+ * run_child_env () - same as cm_common's run_child (), but lets the caller
+ * pass extra "KEY=VALUE" environment entries that apply only to the child
+ * process, instead of mutating the whole server process's environment via
+ * putenv () before fork ()/CreateProcess ().
+ *
+ * envp (in) : NULL-terminated array of "KEY=VALUE" strings to add to (or
+ *             override in) the child's environment. May be NULL, in which
+ *             case the child simply inherits the current environment,
+ *             identical to run_child ().
+ */
+int
+run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
+              char *stderr_file, const char *envp[], int *exit_status)
+{
+  int new_pid;
+  STARTUPINFO start_info;
+  PROCESS_INFORMATION proc_info;
+  BOOL res;
+  int i, cmd_arg_len;
+  char cmd_arg[1024];
+  BOOL inherit_flag = FALSE;
+  HANDLE hStdIn = INVALID_HANDLE_VALUE;
+  HANDLE hStdOut = INVALID_HANDLE_VALUE;
+  HANDLE hStdErr = INVALID_HANDLE_VALUE;
+  char *env_block = NULL;
+
+  if (exit_status != NULL)
+    *exit_status = 0;
+
+  for (i = 0, cmd_arg_len = 0; argv[i]; i++)
+    {
+      cmd_arg_len += sprintf (cmd_arg + cmd_arg_len, "\"%s\" ", argv[i]);
+    }
+
+  GetStartupInfo (&start_info);
+  start_info.wShowWindow = SW_HIDE;
+
+  if (stdin_file)
+    {
+      hStdIn = CreateFile (stdin_file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+      if (hStdIn != INVALID_HANDLE_VALUE)
+       {
+         SetHandleInformation (hStdIn, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+         start_info.dwFlags = STARTF_USESTDHANDLES;
+         start_info.hStdInput = hStdIn;
+         inherit_flag = TRUE;
+       }
+    }
+  if (stdout_file)
+    {
+      hStdOut =
+       CreateFile (stdout_file, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+      if (hStdOut != INVALID_HANDLE_VALUE)
+       {
+         SetHandleInformation (hStdOut, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+         start_info.dwFlags = STARTF_USESTDHANDLES;
+         start_info.hStdOutput = hStdOut;
+         inherit_flag = TRUE;
+       }
+    }
+  if (stderr_file)
+    {
+      hStdErr =
+       CreateFile (stderr_file, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+                   CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+      if (hStdErr != INVALID_HANDLE_VALUE)
+       {
+         SetHandleInformation (hStdErr, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+         start_info.dwFlags = STARTF_USESTDHANDLES;
+         start_info.hStdError = hStdErr;
+         inherit_flag = TRUE;
+       }
+    }
+
+  if (envp != NULL)
+    {
+      /* NULL on failure just means "inherit parent env unchanged", same as run_child () */
+      env_block = _build_env_block (envp);
+    }
+
+  /* env_block is an ANSI block from GetEnvironmentStrings (), so we must NOT pass
+   * CREATE_UNICODE_ENVIRONMENT here. */
+  res =
+    CreateProcess (argv[0], cmd_arg, NULL, NULL, inherit_flag, CREATE_NO_WINDOW, env_block, NULL, &start_info,
+                  &proc_info);
+
+  if (env_block != NULL)
+    {
+      free (env_block);
+    }
+
+  if (hStdIn != INVALID_HANDLE_VALUE)
+    {
+      CloseHandle (hStdIn);
+    }
+  if (hStdOut != INVALID_HANDLE_VALUE)
+    {
+      CloseHandle (hStdOut);
+    }
+  if (hStdErr != INVALID_HANDLE_VALUE)
+    {
+      CloseHandle (hStdErr);
+    }
+
+  if (res == FALSE)
+    {
+      return -1;
+    }
+
+  new_pid = proc_info.dwProcessId;
+
+  if (wait_flag)
+    {
+      DWORD status = 0;
+      WaitForSingleObject (proc_info.hProcess, INFINITE);
+      GetExitCodeProcess (proc_info.hProcess, &status);
+      if (exit_status != NULL)
+       *exit_status = status;
+      CloseHandle (proc_info.hProcess);
+      CloseHandle (proc_info.hThread);
+      return 0;
+    }
+  else
+    {
+      CloseHandle (proc_info.hProcess);
+      CloseHandle (proc_info.hThread);
+      return new_pid;
+    }
+}
+
+#else /* !WINDOWS */
+
+/*
+ * _merge_envp () - build a NULL-terminated envp[] array (for execve ()).
+ * if the key already exists, overridden else added.
+ */
+static char **
+_merge_envp (const char *const envp[])
+{
+  extern char **environ;
+  int base_count, extra_count, i, j;
+  int total_count = 0;
+  char **merged;
+
+  env_mutex_lock ();
+
+  for (base_count = 0; environ != NULL && environ[base_count] != NULL; base_count++)
+    ;
+  for (extra_count = 0; envp != NULL && envp[extra_count] != NULL; extra_count++)
+    ;
+
+  merged = (char **) malloc (sizeof (char *) * (base_count + extra_count + 1));
+  if (merged == NULL)
+    {
+      env_mutex_unlock ();
+      return NULL;
+    }
+
+  for (i = 0; i < base_count; i++)
+    {
+      size_t key_len = _env_key_len (environ[i]);
+      int overridden = 0;
+
+      for (j = 0; j < extra_count; j++)
+       {
+         if (key_len == _env_key_len (envp[j]) && strncmp (environ[i], envp[j], key_len) == 0)
+           {
+             overridden = 1;
+             break;
+           }
+       }
+
+      if (!overridden)
+       {
+         merged[total_count] = strdup (environ[i]);
+         if (merged[total_count] == NULL)
+           {
+             goto error;
+           }
+         total_count++;
+       }
+    }
+
+  for (j = 0; j < extra_count; j++)
+    {
+      merged[total_count] = strdup (envp[j]);
+      if (merged[total_count] == NULL)
+       {
+         goto error;
+       }
+      total_count++;
+    }
+
+  merged[total_count] = NULL;
+
+  env_mutex_unlock ();
+  return merged;
+
+error:
+  merged[total_count] = NULL;
+  for (i = 0; merged[i] != NULL; i++)
+    {
+      free (merged[i]);
+    }
+  free (merged);
+  env_mutex_unlock ();
+  return NULL;
+}
+
+static void
+_free_envp (char **merged)
+{
+  int i;
+
+  if (merged == NULL)
+    {
+      return;
+    }
+  for (i = 0; merged[i] != NULL; i++)
+    {
+      free (merged[i]);
+    }
+  free (merged);
+}
+
+int
+run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
+              char *stderr_file, const char *envp[], int *exit_status)
+{
+  int pid;
+  char **merged_envp = NULL;
+
+  if (exit_status != NULL)
+    *exit_status = 0;
+
+  if (envp != NULL)
+    {
+      merged_envp = _merge_envp (envp);
+      /* on OOM, merged_envp stays NULL and the child just inherits the
+       * parent's environment unchanged -- same as run_child (). */
+    }
+
+  if (wait_flag)
+    signal (SIGCHLD, SIG_DFL);
+  else
+    signal (SIGCHLD, SIG_IGN);
+
+  pid = fork ();
+  if (pid == 0)
+    {
+      FILE *fp;
+
+      close_all_fds (3);
+
+      if (stdin_file != NULL)
+       {
+         fp = fopen (stdin_file, "r");
+         if (fp != NULL)
+           {
+             dup2 (fileno (fp), 0);
+             fclose (fp);
+           }
+       }
+      if (stdout_file != NULL)
+       {
+         unlink (stdout_file);
+         fp = fopen (stdout_file, "w");
+         if (fp != NULL)
+           {
+             dup2 (fileno (fp), 1);
+             fclose (fp);
+           }
+       }
+      if (stderr_file != NULL)
+       {
+         unlink (stderr_file);
+         fp = fopen (stderr_file, "w");
+         if (fp != NULL)
+           {
+             dup2 (fileno (fp), 2);
+             fclose (fp);
+           }
+       }
+
+      if (merged_envp != NULL)
+       {
+         execve ((const char *) argv[0], (char *const *) argv, merged_envp);
+       }
+      else
+       {
+         execv ((const char *) argv[0], (char *const *) argv);
+       }
+      _exit (127); /* when execve () failed, just _exit () immediately */
+    }
+
+  _free_envp (merged_envp);
+
+  if (pid < 0)
+    {
+      return -1;
+    }
+
+  if (wait_flag)
+    {
+      int status = 0;
+      waitpid (pid, &status, 0);
+      if (exit_status != NULL)
+       {
+         *exit_status = status;
+       }
+      return 0;
+    }
+  else
+    {
+      return pid;
+    }
+}
+#endif
+
 typedef struct _dir_file_node
 {
   char *file_name;

--- a/server/src/cm_server_util.cpp
+++ b/server/src/cm_server_util.cpp
@@ -844,16 +844,6 @@ ut_daemon_start (void)
   signal (SIGTTIN, SIG_IGN);
   signal (SIGTSTP, SIG_IGN);
 
-#if 0
-  /* to make it run in background */
-  signal (SIGHUP, SIG_IGN);
-  childpid = PROC_FORK ();
-  if (childpid > 0)
-    {
-      exit (0);  /* kill parent */
-    }
-#endif
-
   /* setpgrp(); */
   setsid ();            /* become process group leader and  */
   /* disconnect from control terminal */
@@ -865,12 +855,6 @@ ut_daemon_start (void)
       exit (0);  /* kill parent */
     }
 
-#if 0
-  /* change current working directory */
-  chdir ("/");
-  /* clear umask */
-  umask (0);
-#endif
 #endif /* ifndef WINDOWS */
 }
 
@@ -2787,6 +2771,17 @@ _env_key_len (const char *kv)
   return (eq != NULL) ? (size_t) (eq - kv) : strlen (kv);
 }
 
+/*
+ * _env_entry_is_delete () - true if kv is a "KEY=" entry with no value
+ */
+static int
+_env_entry_is_delete (const char *kv)
+{
+  const char *eq = strchr (kv, '=');
+
+  return (eq != NULL) && (eq[1] == '\0');
+}
+
 #if defined(WINDOWS)
 
 /*
@@ -2843,6 +2838,10 @@ _build_env_block (const char *const envp[])
     }
   for (j = 0; j < extra_count; j++)
     {
+      if (_env_entry_is_delete (envp[j]))
+       {
+         continue;
+       }
       merged_size += strlen (envp[j]) + 1;
     }
   merged_size += 1;    /* final block-terminating NUL */
@@ -2880,7 +2879,13 @@ _build_env_block (const char *const envp[])
     }
   for (j = 0; j < extra_count; j++)
     {
-      size_t len = strlen (envp[j]);
+      size_t len;
+
+      if (_env_entry_is_delete (envp[j]))
+       {
+         continue;
+       }
+      len = strlen (envp[j]);
 
       memcpy (q, envp[j], len + 1);
       q += len + 1;
@@ -2894,15 +2899,9 @@ _build_env_block (const char *const envp[])
 }
 
 /*
- * run_child_env () - same as cm_common's run_child (), but lets the caller
- * pass extra "KEY=VALUE" environment entries that apply only to the child
- * process, instead of mutating the whole server process's environment via
- * putenv () before fork ()/CreateProcess ().
- *
  * envp (in) : NULL-terminated array of "KEY=VALUE" strings to add to (or
- *             override in) the child's environment. May be NULL, in which
- *             case the child simply inherits the current environment,
- *             identical to run_child ().
+ *             override in) the child's environment. An entry of the form
+ *             "KEY=" (no value) removes KEY from the child's environment
  */
 int
 run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
@@ -3028,7 +3027,6 @@ run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, 
 
 /*
  * _merge_envp () - build a NULL-terminated envp[] array (for execve ()).
- * if the key already exists, overridden else added.
  */
 static char **
 _merge_envp (const char *const envp[])
@@ -3079,6 +3077,11 @@ _merge_envp (const char *const envp[])
 
   for (j = 0; j < extra_count; j++)
     {
+      if (_env_entry_is_delete (envp[j]))
+       {
+         continue;
+       }
+
       merged[total_count] = strdup (envp[j]);
       if (merged[total_count] == NULL)
        {

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -95,6 +95,12 @@ typedef unsigned __int64 uint64_t;
 #define AIX_STACKSIZE_PER_THREAD           (10*1024*1024)
 #endif
 
+#if defined (WINDOWS)
+#define STRTOK(buf,delim,saveptr)  strtok_s (buf, delim, saveptr)
+#else
+#define STRTOK(buf,delim,saveptr)  strtok_r (buf, delim, saveptr)
+#endif
+
 typedef enum
 {
   TIME_STR_FMT_DATE = NV_ADD_DATE,

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -209,7 +209,7 @@ int ut_run_child (const char *bin_path, const char *const argv[],
                   int wait_flag, const char *stdin_file,
                   const char *stdout_file, const char *stderr_file, int *exit_status);
 int run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
-                   char *stderr_file, const char *envp[], int *exit_status);
+                   char *stderr_file, int *exit_status, const char *envp[] = NULL);
 
 void env_mutex_lock (void);
 void env_mutex_unlock (void);

--- a/server/src/cm_server_util.h
+++ b/server/src/cm_server_util.h
@@ -208,6 +208,11 @@ int gettimeofday (struct timeval *tp, void *tzp);
 int ut_run_child (const char *bin_path, const char *const argv[],
                   int wait_flag, const char *stdin_file,
                   const char *stdout_file, const char *stderr_file, int *exit_status);
+int run_child_env (const char *const argv[], int wait_flag, const char *stdin_file, char *stdout_file,
+                   char *stderr_file, const char *envp[], int *exit_status);
+
+void env_mutex_lock (void);
+void env_mutex_unlock (void);
 
 int IsValidUserName (const char *pUserName);
 int ut_validate_auth (nvplist *req);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26861

**Description**
* support async interface for following apis
  * loaddb
  * unloaddb
  * createdb,
  * optimizedb
  * checkdb
  * copydb
  * renamedb
  * compactdb
  * restoredb
  * backupdb
  * addvoldb
* above APIs can adds the '**async=yes**' parameter to the request, then the CMS will perform the task in the background, return the **UUID**, and return immediately.
* UUID is 64bits integer
* request sample:
```
{
   "task":"createdb",
   "dbname":"testdb",
   "numpage":"3024000",
   "pagesize":"4096",
   "logsize":"10240",
   "logpagesize":"40960",
   "genvolpath":"$CUBRID/databases/testdb",
   "logvolpath":"$CUBRID/databases/testdb",
   "exvol":[{"testdb_data_x001":"data;100;/home/kshan/db/CUBRID/databases/testdb"}],
   "charset":"en_US.utf8",
   "overwrite_config_file":"YES",
   "async":"yes"
 }
```
* response sample:
```
{
   "job-status" : "running",
   "note" : "none",
   "status" : "success",
   "task" : "createdb",
   "uuid" : "14"
}
```
* The UUID is a key used by the **gettaskstatus** task to check the job's status, and it is retained for 1 hour by default.
* To change the retention time of the UUID, add 'async_job_ttl_sec=7200' to cm.conf, 7200 is the seconds to retain UUID.
* to check status of job, send gettaskstatus task with UUID previously received
```
{
  "task":"gettaskstatus",
  "token":"cdfb4c5717170c5e9c6856b4d1c61ee8132bcc7d82bd609066ed9ece2554c47f7926f07dd201b6aa",
  "uuid":"14"
}
```
* response when job with UUID 14 is still running
```
{
   "job-status" : "running",
   "note" : "none",
   "status" : "success",
   "uuid" : "10"
}
```
* response if the job with UUID 3 completed successfully
```
{
   "__EXEC_TIME" : "66620 ms",
   "job-status" : "success",
   "note" : "none",
   "status" : "success",
   "task" : "createdb",
   "uuid" : "3"
}
```
* response when requested UUID does not exist
```
{
   "note" : "invalid uuid",
   "status" : "failure"
}
```
* response when job with UUID 6 failed.
```
{
   "__EXEC_TIME" : "26 ms",
   "job-status" : "error",
   "note" : "Couldn't create database.<end>Database \"testdb\" already exists.<end>",
   "status" : "failure",
   "task" : "createdb",
   "uuid" : "6"
}
```

**Remarks**
* 개발 시스템에 테스트 빌드를 올려놓았으니 참조하세요
  * http://192.168.2.38/CUBRID-11.5.0.2456-f8407ce-Linux.x86_64.sh
  * http://192.168.2.38/CUBRID-11.5.0.2456-f8407ce-Linux.x86_64.tar.gz
  * run_child () 를 run_child_env ()로 바꿔야할 것 같습니다. 81군데 reference라 일단 이 PR을 develop에 merge한후 하는 것이 좋을듯 합니다.
  * Engine의 src/cm_common/cm_utils.c 에 정의된 make_temp_filepath () 의 thread-safety 문제가 지적되었습니다. 이 make_temp_filepath ()의 refactor는 [#7780](https://github.com/CUBRID/cubrid/pull/7780)에서 수정을 제안했는데, 문제가 만약 cm_common의 수정을 하면 이 수정을 다른 CUBRID Engine에 적용할때, Engine source를 또 backport 해야한다는 것입니다.
  * Best choice는 엔진에 정의/수정하려는 make_temp_filepath ()를 변경하는 7780 PR을 close하고 이것을 cm_server_util.cpp 등에 포함시키는 것입니다. 이러면, 이 변경에 대한 부분은 engine code 수정 없이 CMS hash code만 update 하면 가능할 것으로 생각됩니다.